### PR TITLE
Enables CI with Elasticsearch

### DIFF
--- a/.ci/functions/imports.sh
+++ b/.ci/functions/imports.sh
@@ -25,7 +25,7 @@ if [[ -z $es_node_name ]]; then
 
   export es_node_name=instance
   export elastic_password=changeme
-  export elasticsearch_image=elasticsearch
+  export elasticsearch_image=elasticsearch-oss
   export elasticsearch_url=https://elastic:${elastic_password}@${es_node_name}:9200
   if [[ $TEST_SUITE != "platinum" ]]; then
     export elasticsearch_url=http://${es_node_name}:9200

--- a/.ci/run-elasticsearch.sh
+++ b/.ci/run-elasticsearch.sh
@@ -40,38 +40,9 @@ environment=($(cat <<-END
   --env path.repo=/tmp
   --env repositories.url.allowed_urls=http://snapshot.test*
   --env action.destructive_requires_name=false
-  --env ingest.geoip.downloader.enabled=false
+  --env node.roles=data,data_cold,data_content,data_frozen,data_hot,data_warm,ingest,master,remote_cluster_client
 END
 ))
-if [[ "$TEST_SUITE" == "platinum" ]]; then
-  environment+=($(cat <<-END
-    --env ELASTIC_PASSWORD=$elastic_password
-    --env xpack.license.self_generated.type=trial
-    --env xpack.security.enabled=true
-    --env xpack.security.http.ssl.enabled=true
-    --env xpack.security.http.ssl.verification_mode=certificate
-    --env xpack.security.http.ssl.key=certs/testnode.key
-    --env xpack.security.http.ssl.certificate=certs/testnode.crt
-    --env xpack.security.http.ssl.certificate_authorities=certs/ca.crt
-    --env xpack.security.transport.ssl.enabled=true
-    --env xpack.security.transport.ssl.verification_mode=certificate
-    --env xpack.security.transport.ssl.key=certs/testnode.key
-    --env xpack.security.transport.ssl.certificate=certs/testnode.crt
-    --env xpack.security.transport.ssl.certificate_authorities=certs/ca.crt
-END
-))
-  volumes+=($(cat <<-END
-    --volume $ssl_cert:/usr/share/elasticsearch/config/certs/testnode.crt
-    --volume $ssl_key:/usr/share/elasticsearch/config/certs/testnode.key
-    --volume $ssl_ca:/usr/share/elasticsearch/config/certs/ca.crt
-END
-))
-else
-  environment+=($(cat <<-END
-    --env node.roles=data,data_cold,data_content,data_frozen,data_hot,data_warm,ingest,master,remote_cluster_client
-END
-))
-fi
 
 cert_validation_flags=""
 if [[ "$TEST_SUITE" == "platinum" ]]; then
@@ -114,7 +85,7 @@ END
   docker run \
     --name "$node_name" \
     --network "$network_name" \
-    --env "ES_JAVA_OPTS=-Xms1g -Xmx1g -da:org.elasticsearch.xpack.ccr.index.engine.FollowingEngineAssertions" \
+    --env "ES_JAVA_OPTS=-Xms1g -Xmx1g \
     "${environment[@]}" \
     "${volumes[@]}" \
     --publish "$http_port":9200 \

--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -1,6 +1,6 @@
 ---
 STACK_VERSION:
-  - 7.x-SNAPSHOT
+  - 7.10.2
 
 RUBY_TEST_VERSION:
 - 3.0
@@ -10,6 +10,5 @@ RUBY_TEST_VERSION:
 
 TEST_SUITE:
 - free
-- platinum
 
 exclude: ~

--- a/.github/actions/elasticsearch/Dockerfile
+++ b/.github/actions/elasticsearch/Dockerfile
@@ -1,0 +1,9 @@
+FROM docker:stable
+
+RUN apk add --update bash
+
+COPY run.sh /run.sh
+
+RUN chmod +x /run.sh
+
+ENTRYPOINT ["/run.sh"]

--- a/.github/actions/elasticsearch/action.yml
+++ b/.github/actions/elasticsearch/action.yml
@@ -1,0 +1,28 @@
+name: 'Run Cluster'
+description: 'This action spins up a Cluster instance that can be accessed and used in your subsequent steps.'
+author: 'opensearch-dev'
+
+inputs:
+  stack-version:
+    description: 'The version of the Elastic Stack you want to run'
+    required: true
+  nodes:
+    description: 'Number of nodes in the cluster'
+    required: false
+    default: 1
+  port:
+    description: 'Port where you want to run the cluster'
+    required: false
+    default: 9200
+  elasticsearch_password:
+    description: 'The password for the user elastic in your cluster'
+    required: false
+    default: 'admin'
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  env:
+    STACK_VERSION: ${{ inputs.stack-version }}
+    NODES: ${{ inputs.nodes }}
+    PORT: ${{ inputs.port }}

--- a/.github/actions/elasticsearch/run.sh
+++ b/.github/actions/elasticsearch/run.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+if [[ -z $STACK_VERSION ]]; then
+  echo -e "\033[31;1mERROR:\033[0m Required environment variable [STACK_VERSION] not set\033[0m"
+  exit 1
+fi
+
+MAJOR_VERSION=`echo ${STACK_VERSION} | cut -c 1`
+
+docker network create cluster
+
+for (( node=1; node<=${NODES-1}; node++ ))
+do
+  port_com=$((9300 + $node - 1))
+  UNICAST_HOSTS+="es$node:${port_com},"
+done
+
+for (( node=1; node<=${NODES-1}; node++ ))
+do
+  port=$((PORT + $node - 1))
+  port_com=$((9300 + $node - 1))
+  docker run \
+    --rm \
+    --env "node.name=es${node}" \
+    --env "cluster.name=docker-elasticsearch" \
+    --env "cluster.initial_master_nodes=es1" \
+    --env "discovery.seed_hosts=es1" \
+    --env "cluster.routing.allocation.disk.threshold_enabled=false" \
+    --env "bootstrap.memory_lock=true" \
+    --env "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
+    --env "http.port=${port}" \
+    --env "action.destructive_requires_name=false" \
+    --ulimit nofile=65536:65536 \
+    --ulimit memlock=-1:-1 \
+    --publish "${port}:${port}" \
+    --detach \
+    --network=cluster \
+    --name="es${node}" \
+    docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+done
+
+docker run \
+  --network cluster \
+  --rm \
+  appropriate/curl \
+  --max-time 120 \
+  --retry 120 \
+  --retry-delay 1 \
+  --retry-connrefused \
+  --show-error \
+  --silent \
+  http://es1:$PORT
+
+sleep 10
+
+echo "Elasticsearch up and running"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,14 @@ name: 7.x
 on:
   push:
     branches:
-      - 7.x
+      - main
+    paths-ignore:
+      - 'README.md'
   pull_request:
     branches:
-      - 7.x
+      - main
+    paths-ignore:
+      - 'README.md'
 jobs:
   test-ruby:
     env:
@@ -14,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby-9.2 ]
+        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -24,9 +28,9 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: elastic/elastic-github-actions/elasticsearch@master
+    - uses: ./.github/actions/elasticsearch
       with:
-        stack-version: 7.x-SNAPSHOT
+        stack-version: 7.10.2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
### Description
 - Enables CI and uses  Elasticsearch server for running
 the unit and integration tests.

- CI checks will run on main branch and all pull requests to the main
 branch. It will also run after the a PR has been merged and commit
 has been pushed to the main branch

- Rename 7.x.yml in workflow to main.yml and freeze client version at
 7.10.2
 
### Issues Resolved
part of #2 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
