### PR TITLE
Remove place holder link at README file

### DIFF
--- a/opensearch-api/README.md
+++ b/opensearch-api/README.md
@@ -54,9 +54,6 @@ client.search(index: 'myindex', body: { query: { match: { title: 'test' } } })
 # => {"took"=>2, ..., "hits"=>{"total":5, ...}}
 ```
 
-Full documentation and examples are included as RDoc annotations in the source code
-will be available online at <placeholder_rubydoc_opensearch_api>.
-
 ### Usage with a custom client
 
 When you want to mix the library into your own client, it must conform to a following _contract_:

--- a/opensearch-transport/README.md
+++ b/opensearch-transport/README.md
@@ -69,8 +69,6 @@ without any configuration:
     response = client.perform_request 'GET', '_cluster/health'
     # => #<OpenSearch::Transport::Transport::Response:0x007fc5d506ce38 @status=200, @body={ ... } >
 
-Full documentation is available at <placeholder_rubydoc_opensearch_transport>.
-
 ## Configuration
 
 * [Setting Hosts](#setting-hosts)

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -66,11 +66,9 @@ Please refer to the specific library documentation for details:
 
 * **Transport**:
    [[README]](https://github.com/opensearch-project/opensearch-ruby/blob/main/opensearch-transport/README.md)
-   [[Documentation]](<placeholder_rubydoc_opensearch_transport>)
 
 * **API**:
    [[README]](https://github.com/opensearch-project/opensearch-ruby/blob/main/opensearch-api/README.md)
-   [[Documentation]](placeholder_rubydoc_opensearch_api)
 
 ## Development
 


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Remove place holder link at README file. Will add documentation link later.
 
### Issues Resolved
#18 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
