### PR TITLE
Add script to build gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Gemfile.lock
 .idea/*
 profile/**/data/*.json
 .byebug_history
+dist/

--- a/release/build.sh
+++ b/release/build.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+# This is intended to be run the  root directory. `release/build.sh`
+set -e
+
+GIT_ROOT=`git rev-parse --show-toplevel`
+
+cd $GIT_ROOT # We need to start from repository root
+
+rm -rf dist
+mkdir dist
+
+#####################################################
+#      Building opensearch-api                      #
+#                                                   #
+#####################################################
+
+echo 'Building opensearch-api'
+cd opensearch-api;
+gem build opensearch-api.gemspec
+
+echo 'Move Gem Location'
+mv -v opensearch-api*.gem $GIT_ROOT/dist/
+
+#####################################################
+#      Building opensearch-transport                #
+#                                                   #
+#####################################################
+cd $GIT_ROOT
+echo 'Building opensearch-transport'
+cd opensearch-transport;
+gem build opensearch-transport.gemspec
+
+echo 'Move Gem Location'
+mv -v opensearch-transport*.gem $GIT_ROOT/dist/
+
+
+#####################################################
+#      Building opensearch                          #
+#                                                   #
+#####################################################
+cd $GIT_ROOT
+echo 'Building opensearch'
+cd opensearch;
+gem build opensearch.gemspec
+
+echo 'Move Gem Location'
+mv -v opensearch*.gem $GIT_ROOT/dist/
+
+
+#####################################################
+#      Building opensearch-dsl                      #
+#                                                   #
+#####################################################
+cd $GIT_ROOT
+echo 'Building opensearch-dsl'
+cd opensearch-dsl;
+gem build opensearch-dsl.gemspec
+
+echo 'Move Gem Location'
+mv -v opensearch-dsl*.gem $GIT_ROOT/dist/
+
+echo 'List gems to be published: '
+ls -l $GIT_ROOT/dist


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
This script will build following gems
1. opensearch
2. opensearch-api
3. opensearch-transport
4. opensearch-dsl

and will be moved inside dist folder
 
### Issues Resolved
#23 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
