### PR TITLE
Update gem name to opensearch-ruby

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           ruby -v
           rake bundle:clean
           rake bundle:install
-      - name: opensearch
+      - name: opensearch-ruby
         run: cd opensearch && bundle exec rake test:all
       - name: opensearch-transport
         run: cd opensearch-transport && bundle exec rake test:all
@@ -116,7 +116,7 @@ jobs:
           ruby -v
           rake bundle:clean
           rake bundle:install
-      - name: opensearch
+      - name: opensearch-ruby
         run: cd opensearch && bundle exec rake test:all
       - name: opensearch-transport
         run: cd opensearch-transport && bundle exec rake test:all

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ For more information, see [opensearch.org](https://opensearch.org/).
 
 To add the client to your project, install it using [RubyGem](https://rubygems.org/)
 
-`gem install opensearch`
+`gem install opensearch-ruby`
 
 or, install it from a source code checkout:
 ```bash
 git clone https://github.com/opensearch-project/opensearch-ruby.git
 cd opensearch-ruby/opensearch
 gem build opensearch.gemspec
-gem install opensearch-<version>.gem
+gem install opensearch-ruby-<version>.gem
 ```
 
 Import the client as a module:
@@ -44,7 +44,10 @@ require 'opensearch'
 
 
 # If you want to use authentication credentials
-client = OpenSearch::Client.new url: 'https://admin:admin@localhost:9200', log: true
+client = OpenSearch::Client.new(
+  host: 'https://admin:admin@localhost:9200',    # For testing only. Don't store credentials in code.
+  transport_options: { ssl: { verify: false } }  # For testing only. Use certificate for validation.
+)
 
 # If you don't want to use authentication credentials
 #client = OpenSearch::Client.new url: 'http://localhost:9200', log: true

--- a/opensearch-api/Gemfile
+++ b/opensearch-api/Gemfile
@@ -34,7 +34,7 @@ if File.exist? File.expand_path("../../opensearch-transport", __FILE__)
 end
 
 if File.exist? File.expand_path("../../opensearch/opensearch.gemspec", __FILE__)
-  gem 'opensearch', path: File.expand_path("../../opensearch", __FILE__), require: false
+  gem 'opensearch-ruby', path: File.expand_path("../../opensearch", __FILE__), require: false
 end
 
 group :development do

--- a/opensearch-dsl/Gemfile
+++ b/opensearch-dsl/Gemfile
@@ -30,7 +30,7 @@ source 'https://rubygems.org'
 gemspec
 
 if File.exist? File.expand_path('../../opensearch/opensearch.gemspec', __FILE__)
-  gem 'opensearch', path: File.expand_path('../../opensearch', __FILE__), require: false
+  gem 'opensearch-ruby', path: File.expand_path('../../opensearch', __FILE__), require: false
 end
 
 if File.exist? File.expand_path('../../opensearch-transport', __FILE__)

--- a/opensearch-transport/Gemfile
+++ b/opensearch-transport/Gemfile
@@ -34,7 +34,7 @@ if File.exist? File.expand_path('../opensearch-api/opensearch-api.gemspec', __di
 end
 
 if File.exist? File.expand_path('../opensearch/opensearch.gemspec', __dir__)
-  gem 'opensearch', path: File.expand_path('../opensearch', __dir__), require: false
+  gem 'opensearch-ruby', path: File.expand_path('../opensearch', __dir__), require: false
 end
 
 group :development, :test do

--- a/opensearch-transport/opensearch-transport.gemspec
+++ b/opensearch-transport/opensearch-transport.gemspec
@@ -60,7 +60,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'curb' unless defined? JRUBY_VERSION
-  s.add_development_dependency 'opensearch', ['>= 7', '< 8.0.0']
+  s.add_development_dependency 'opensearch-ruby'
   s.add_development_dependency 'hashie'
   s.add_development_dependency 'httpclient'
   s.add_development_dependency 'manticore' if defined? JRUBY_VERSION

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -24,11 +24,11 @@ The client's API is compatible with OpenSearch's API versions from 1.0.0 till cu
 
 Install the package from [Rubygems](https://rubygems.org):
 
-    gem install opensearch
+    gem install opensearch-ruby
 
 To use an unreleased version, either add it to your `Gemfile` for [Bundler](http://gembundler.com):
 
-    gem 'opensearch', git: 'git://github.com/opensearch-project/opensearch-ruby.git'
+    gem 'opensearch-ruby', git: 'git://github.com/opensearch-project/opensearch-ruby.git'
 
 or install it from a source code checkout:
 

--- a/opensearch/opensearch.gemspec
+++ b/opensearch/opensearch.gemspec
@@ -29,7 +29,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'opensearch/version'
 
 Gem::Specification.new do |s|
-  s.name          = 'opensearch'
+  s.name          = 'opensearch-ruby'
   s.version       = OpenSearch::VERSION
   s.authors       = ['Jayesh Hathila', 'Vamshi Vijay Nakkirtha', 'Vijayan Balasubramanian' , 'Yuvraj Jaiswal']
   s.email         = ['jayehh@amazon.com', 'vamshin@amazon.com', 'balasvij@amazon.com', 'jaiyuvra@amazon.com']


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Since gem name opensearch is taken, update name to
opensearch-ruby to avoid conflict.

 
### Issues Resolved
#23  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
