### PR TITLE
fixes the faraday dependency config to match latest v0.17.5

### DIFF
--- a/opensearch-transport/opensearch-transport.gemspec
+++ b/opensearch-transport/opensearch-transport.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'multi_json'
-  s.add_dependency 'faraday', '~> 1'
+  s.add_dependency 'faraday', '< 1.0'
 
   s.add_development_dependency 'ansi'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
### Description
This fix attempts to resolve the faraday gem version to point to the latest available version
 
### Issues Resolved
This fix is for Issue #51
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
