### PR TITLE
Remove broken link from Readme

### DIFF
--- a/opensearch-api/README.md
+++ b/opensearch-api/README.md
@@ -185,7 +185,7 @@ time rake test:unit
 time rake test:integration
 ```
 
-We run the test suite for OpenSearch's Rest API tests. You can read more about this in [the test runner README](https://github.com/opensearch-project/opensearch-ruby/tree/main/api-spec-testing#rest-api-yaml-test-runner).
+We run the test suite for OpenSearch's Rest API tests.
 
 The `rest_api` needs the test files from OpenSearch. You can run the rake task to download the test artifacts in the root folder of the project. This task needs a running cluster to determine which version and build hash of OpenSearch to use and test against. `TEST_OPENSEARCH_SERVER=http://localhost:9200 rake opensearch:download_artifacts`. This will download the necessary files used for the integration tests to `./tmp`.
 


### PR DESCRIPTION
Signed-off-by: Jayesh Hathila <jayehh@amazon.com>

### Description
Removing broken link from Readme. Will add back once we have correct doc in place.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-ruby/issues/53
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
