### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby-9.3 ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby-9.3 ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby-9.3 ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
     steps:
       - uses: actions/checkout@v2
       - name: Increase system limits

--- a/opensearch-api/README.md
+++ b/opensearch-api/README.md
@@ -185,7 +185,7 @@ time rake test:unit
 time rake test:integration
 ```
 
-We run the test suite for OpenSearch's Rest API tests. You can read more about this in [the test runner README](https://github.com/opensearch-project/opensearch-ruby/tree/main/api-spec-testing#rest-api-yaml-test-runner).
+We run the test suite for OpenSearch's Rest API tests.
 
 The `rest_api` needs the test files from OpenSearch. You can run the rake task to download the test artifacts in the root folder of the project. This task needs a running cluster to determine which version and build hash of OpenSearch to use and test against. `TEST_OPENSEARCH_SERVER=http://localhost:9200 rake opensearch:download_artifacts`. This will download the necessary files used for the integration tests to `./tmp`.
 


### PR DESCRIPTION
Signed-off-by: Peter Goldstein <peter.m.goldstein@gmail.com>

### Description
Adds Ruby 3.1 to the CI matrix
 
### Issues Resolved
Fixes a bug in the existing CI matrix.  Github Actions will truncate an unquoted 3.0 to 3, and thus pull in the latest Ruby 3 version for that entry in the matrix.  At this time that's Ruby 3.1.1, which is not what's intended.  Adding quotes to the 3.0 resolves this issue.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
