### PR TITLE
Add support to test against multiple versions of OpenSearch

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,15 +1,12 @@
-name: Integration
+name: Integration with Compatibility
 on:
   push:
     branches:
       - "*"
-    paths-ignore:
-      - 'README.md'
   pull_request:
     branches:
       - "*"
-    paths-ignore:
-      - 'README.md'
+
 jobs:
   test-opensearch:
     env:
@@ -18,7 +15,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
         cluster-version: [ "1.0.0", "1.0.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.3.0", "1.3.1" ]
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +31,7 @@ jobs:
           disable-security: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: 3.1
       - name: Build and test with Rake
         run: |
           sudo apt-get update
@@ -60,7 +56,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
         cluster-version: [ "1.0.0", "1.0.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.3.0", "1.3.1" ]
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +72,7 @@ jobs:
           disable-security: false
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: 3.1
       - name: Build and test with Rake
         run: |
           sudo apt-get update
@@ -88,39 +83,3 @@ jobs:
           rake bundle:install
       - name: opensearch
         run: cd opensearch && bundle exec rake test_security:all
-
-  test-opendistro:
-    name: test-opendistro
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Increase system limits
-        run: |
-          sudo swapoff -a
-          sudo sysctl -w vm.swappiness=1
-          sudo sysctl -w fs.file-max=262144
-          sudo sysctl -w vm.max_map_count=262144
-      - name: Launch Opendistro cluster
-        run: |
-          make cluster.clean cluster.opendistro.build cluster.opendistro.start
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-      - name: Build and test with Rake
-        run: |
-          sudo apt-get update
-          sudo apt-get install libcurl4-openssl-dev
-          ruby -v
-          rake bundle:clean
-          rake bundle:install
-      - name: opensearch-ruby
-        run: cd opensearch && bundle exec rake test:all
-      - name: opensearch-transport
-        run: cd opensearch-transport && bundle exec rake test:all
-      - name: opensearch-api
-        run: cd opensearch-api && bundle exec rake test:spec
-      - name: opensearch-dsl
-        run: cd opensearch-dsl && bundle exec rake test:all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
-        cluster-version: [ "1.0.0", "1.0.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.3.0", "1.3.1" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +30,7 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
       - uses: ./.github/actions/opensearch
         with:
-          cluster-version: ${{ matrix.cluster-version }}
+          cluster-version: latest
           disable-security: true
       - uses: ruby/setup-ruby@v1
         with:
@@ -61,7 +60,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
-        cluster-version: [ "1.0.0", "1.0.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.3.0", "1.3.1" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +71,7 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
       - uses: ./.github/actions/opensearch
         with:
-          cluster-version: ${{ matrix.cluster-version }}
+          cluster-version: latest
           disable-security: false
       - uses: ruby/setup-ruby@v1
         with:

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,18 @@
+- [Compatibility with OpenSearch](#compatibility-with-opensearch)
+
+## Compatibility with OpenSearch
+
+The below matrix shows the compatibility of the [`opensearch-ruby`](https://rubygems.org/gems/opensearch-ruby) with versions of [`OpenSearch`](https://opensearch.org/downloads.html#opensearch).
+
+| OpenSearch Version | Client Version |
+| --- | --- |
+| 1.0.0 | 1.0.0 |
+| 1.0.1 | 1.0.0 |
+| 1.1.0 | 1.0.0 |
+| 1.2.0 | 1.0.0 |
+| 1.2.1 | 1.0.0 |
+| 1.2.2 | 1.0.0 |
+| 1.2.3 | 1.0.0 |
+| 1.2.4 | 1.0.0 |
+| 1.3.0 | 1.0.0 |
+| 1.3.1 | 1.0.0 |


### PR DESCRIPTION
### Description
Adding support to run tests against multiple versions of OpenSearch in the CI. I separated out the `compatibility.yml` since the matrix was becoming huge in the `main.yml` with multiple ruby versions.
 
### Issues Resolved
#56 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
