### PR TITLE
Bump client version to 2.0 and add OpenSearch 2.0

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cluster-version: [ "1.0.0", "1.0.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.3.0", "1.3.1" ]
+        cluster-version: [ "1.0.0", "1.0.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.3.0", "1.3.1", "2.0.0" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cluster-version: [ "1.0.0", "1.0.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.3.0", "1.3.1" ]
+        cluster-version: [ "1.0.0", "1.0.1", "1.1.0", "1.2.0", "1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.3.0", "1.3.1", "2.0.0" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,4 +1,5 @@
 - [Compatibility with OpenSearch](#compatibility-with-opensearch)
+- [Upgrading](#upgrading)
 
 ## Compatibility with OpenSearch
 

--- a/opensearch-api/lib/opensearch/api/version.rb
+++ b/opensearch-api/lib/opensearch/api/version.rb
@@ -26,6 +26,6 @@
 
 module OpenSearch
   module API
-    VERSION = '1.0.0'.freeze
+    VERSION = '2.0.0'.freeze
   end
 end

--- a/opensearch-dsl/lib/opensearch/dsl/version.rb
+++ b/opensearch-dsl/lib/opensearch/dsl/version.rb
@@ -26,6 +26,6 @@
 
 module OpenSearch
   module DSL
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/opensearch-transport/lib/opensearch/transport/version.rb
+++ b/opensearch-transport/lib/opensearch/transport/version.rb
@@ -26,6 +26,6 @@
 
 module OpenSearch
   module Transport
-    VERSION = '1.0.0'.freeze
+    VERSION = '2.0.0'.freeze
   end
 end

--- a/opensearch/lib/opensearch/version.rb
+++ b/opensearch/lib/opensearch/version.rb
@@ -25,5 +25,5 @@
 # under the License.
 
 module OpenSearch
-  VERSION = '1.0.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/opensearch/opensearch.gemspec
+++ b/opensearch/opensearch.gemspec
@@ -61,8 +61,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4'
 
-  s.add_dependency 'opensearch-transport', '1.0.0'
-  s.add_dependency 'opensearch-api',       '1.0.0'
+  s.add_dependency 'opensearch-transport', '2.0.0'
+  s.add_dependency 'opensearch-api',       '2.0.0'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'byebug' unless defined?(JRUBY_VERSION) || defined?(Rubinius)

--- a/opensearch/spec/integration/security_disabled/validation_integration_spec.rb
+++ b/opensearch/spec/integration/security_disabled/validation_integration_spec.rb
@@ -27,7 +27,7 @@ require 'spec_helper'
 require 'logger'
 
 describe 'OpenSearch validation integration' do
-  it 'Validates for OpenSearch 1.0.0-SNAPSHOT' do
+  it 'Validates for OpenSearch' do
     client = OpenSearch::Client.new(
       host: OPENSEARCH_URL,
       logger: Logger.new($stderr)

--- a/opensearch/spec/unit/opensearch_product_validation_spec.rb
+++ b/opensearch/spec/unit/opensearch_product_validation_spec.rb
@@ -84,7 +84,7 @@ describe 'OpenSearch: Validation' do
     end
   end
 
-  context 'When Elasticsearch replies with status 403' do
+  context 'When OpenSearch replies with status 403' do
     let(:status) { 403 }
     let(:body) { {}.to_json }
 
@@ -105,9 +105,9 @@ describe 'OpenSearch: Validation' do
     end
   end
 
-  context 'When the OpenSearch version is 1.0.0-SNAPSHOT' do
+  context 'When the OpenSearch version is 2.0.0' do
     context 'With a valid OpenSearch response' do
-      let(:body) { { 'version' => { 'number' => '1.0.0-SNAPSHOT', 'distribution' => 'opensearch' } }.to_json }
+      let(:body) { { 'version' => { 'number' => '2.0.0', 'distribution' => 'opensearch' } }.to_json }
       let(:headers) do
         {
           'content-type' => 'json'
@@ -123,7 +123,7 @@ describe 'OpenSearch: Validation' do
     end
 
     context 'When the distribution is not present' do
-      let(:body) { { 'version' => { 'number' => '1.0.0-SNAPSHOT' } }.to_json }
+      let(:body) { { 'version' => { 'number' => '2.0.0' } }.to_json }
       it 'Fails validation' do
         verify_request_stub
 
@@ -187,7 +187,7 @@ describe 'OpenSearch: Validation' do
     end
 
     let(:headers) { { 'content-type' => 'application/yaml'} }
-    let(:body) { "---\nversion:\n  number: \"1.0.0-SNAPSHOT\"\n  distribution: \"opensearch\"\n" }
+    let(:body) { "---\nversion:\n  number: \"2.0.0\"\n  distribution: \"opensearch\"\n" }
 
     it 'validates' do
       verify_request_stub


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
* Bump client version to 2.0.0.
* Add OpenSearch 2.0 to the test matrix.
 
### Issues Resolved
#68 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
