### PR TITLE
Remove deprecated escape_utils.

### DIFF
--- a/opensearch-api/lib/opensearch/api/utils.rb
+++ b/opensearch-api/lib/opensearch/api/utils.rb
@@ -40,7 +40,7 @@ module OpenSearch
       # @api private
       def __escape(string)
         return string if string == '*'
-        defined?(EscapeUtils) ? EscapeUtils.escape_uri(string.to_s) : CGI.escape(string.to_s)
+        CGI.escape(string.to_s)
       end
 
       # Create a "list" of values from arguments, ignoring nil values and encoding special characters.

--- a/opensearch-api/opensearch-api.gemspec
+++ b/opensearch-api/opensearch-api.gemspec
@@ -79,7 +79,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'hashie'
 
   s.add_development_dependency 'cane'
-  s.add_development_dependency 'escape_utils' unless defined? JRUBY_VERSION
   s.add_development_dependency 'jbuilder'
   s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'simplecov'

--- a/opensearch-api/spec/opensearch/api/utils_spec.rb
+++ b/opensearch-api/spec/opensearch/api/utils_spec.rb
@@ -48,16 +48,9 @@ describe OpenSearch::API::Utils do
       expect(utils.__escape('*')).to eq('*')
     end
 
-    it 'users CGI.escape by default' do
+    it 'uses CGI.escape by default' do
       expect(CGI).to receive(:escape).and_call_original
       expect(utils.__escape('foo bar')).to eq('foo+bar')
-    end
-
-    it 'uses the escape_utils gem when available', unless: defined?(JRUBY_VERSION) do
-      require 'escape_utils'
-      expect(CGI).not_to receive(:escape)
-      expect(EscapeUtils).to receive(:escape_uri).and_call_original
-      expect(utils.__escape('foo bar')).to eq('foo%20bar')
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

### Description

According to https://github.com/brianmario/escape_utils, _EscapeUtils used to provide optimized escaping function to replace the slow methods provided by Ruby. Since Ruby 2.5, the various CGI escape methods have been severely optimized and most EscapeUtils methods became irrelevant and were deprecated._ 

It outputs a warning at runtime, too: https://github.com/opensearch-project/opensearch-ruby/runs/6942537657?check_suite_focus=true 

```
  #__listify
EscapeUtils.escape_url is deprecated. Use CGI.escape instead, performance is similar
    creates a list from a single value
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
