### PR TITLE
Faraday 2 support for opensearch-transport 1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
         run: cd opensearch && bundle exec rake test:all
       - name: opensearch-transport
         run: cd opensearch-transport && bundle exec rake test:all
+      - name: opensearch-transport with faraday 1
+        run: cd opensearch-transport && rm -f Gemfile.lock && FARADAY_VERSION='~> 1.0' bundle exec rake test:all
       - name: opensearch-api
         run: cd opensearch-api && bundle exec rake test:spec
       - name: opensearch-dsl

--- a/opensearch-transport/Gemfile
+++ b/opensearch-transport/Gemfile
@@ -37,6 +37,9 @@ if File.exist? File.expand_path('../opensearch/opensearch.gemspec', __dir__)
   gem 'opensearch-ruby', path: File.expand_path('../opensearch', __dir__), require: false
 end
 
+ENV['FARADAY_VERSION'] = '~> 1.0' if RUBY_VERSION.to_f < 2.7
+gem 'faraday', ENV['FARADAY_VERSION'], require: false if ENV['FARADAY_VERSION']
+
 group :development, :test do
   gem 'rspec'
   if defined?(JRUBY_VERSION)

--- a/opensearch-transport/README.md
+++ b/opensearch-transport/README.md
@@ -28,16 +28,22 @@ Features overview:
 * Node reloading (based on cluster state) on errors or on demand
 
 For optimal performance, use a HTTP library which supports persistent ("keep-alive") connections,
-such as [patron](https://github.com/toland/patron) or [Typhoeus](https://github.com/typhoeus/typhoeus).
-Just require the library (`require 'patron'`) in your code, and it will be automatically used.
+such as [Patron](https://github.com/toland/patron) or [Typhoeus](https://github.com/typhoeus/typhoeus).
+Most such HTTP libraries are used through the [Faraday](https://rubygems.org/gems/faraday) HTTP library
+and its [adapters](https://github.com/lostisland/awesome-faraday/#adapters).
+
+Just include the library's gem and adapter gem, and require the library and adapter in your code, and it will be automatically used.
+If you don't use Bundler, you may need to require the library explicitly (like `require 'faraday/patron'`).
 
 Currently these libraries will be automatically detected and used:
-- [Patron](https://github.com/toland/patron)
-- [Typhoeus](https://github.com/typhoeus/typhoeus)
-- [HTTPClient](https://rubygems.org/gems/httpclient)
-- [Net::HTTP::Persistent](https://rubygems.org/gems/net-http-persistent)
+- [Patron](https://github.com/toland/patron) through [faraday-patron](https://github.com/lostisland/faraday-patron)
+- [Typhoeus](https://github.com/typhoeus/typhoeus) through [faraday-typhoeus](https://github.com/lostisland/faraday-typhoeus) or its built-in adapter.
+- [HTTPClient](https://rubygems.org/gems/httpclient) through [faraday-httpclient](https://github.com/lostisland/faraday-httpclient)
+- [Net::HTTP::Persistent](https://rubygems.org/gems/net-http-persistent) through [faraday-net_http_persistent](https://github.com/lostisland/faraday-net_http_persistent)
 
-**Note on [Typhoeus](https://github.com/typhoeus/typhoeus)**: You need to use v1.4.0 or up since older versions are not compatible with Faraday 1.0.
+**Note on [Typhoeus](https://github.com/typhoeus/typhoeus)**: You need to use v1.4.0 or up since older versions are not compatible with Faraday 1.0 or higher.
+
+**Note on [Faraday](https://rubygems.org/gems/faraday)**: If you use Faraday 2.0 or higher, if the adapter is in a separate gem, you will likely need to declare that gem as well. Only the Net::HTTP adapter gem is included by default. Faraday 1.x includes most common adapter gems already.
 
 For detailed information, see example configurations [below](#transport-implementations).
 
@@ -350,10 +356,22 @@ as a transport implementation.
 It will auto-detect and use an _adapter_ for _Faraday_ based on gems loaded in your code,
 preferring HTTP clients with support for persistent connections.
 
-To use the [_Patron_](https://github.com/toland/patron) HTTP, for example, just require it:
+Faraday uses adapters, usually in separate gems, to connect to the HTTP library. You need to
+make sure that your code refers to both the HTTP library gem and the adapter gem. See this
+list of [Faraday adapters](https://github.com/lostisland/awesome-faraday/#adapters) for details.
+
+To use the [_Patron_](https://github.com/toland/patron) HTTP, for example, you need to refer to these gems:
+
+```ruby
+gem 'patron'
+gem 'faraday-patron'
+```
+
+If you don't use Bundler, you may need to require the libraries explicitly in your code:
 
 ```ruby
 require 'patron'
+require 'faraday/patron'
 ```
 
 Then, create a new client, and the _Patron_  gem will be used as the "driver":
@@ -396,8 +414,6 @@ constructor, use the `transport_options` key:
 
 To configure the _Faraday_ instance directly, use a block:
 
-    require 'patron'
-
     client = OpenSearch::Client.new(host: 'localhost', port: '9200') do |f|
       f.response :logger
       f.adapter  :patron
@@ -406,8 +422,6 @@ To configure the _Faraday_ instance directly, use a block:
 You can use any standard Faraday middleware and plugins in the configuration block. You can also initialize the transport class yourself, and pass it to the client constructor as the `transport` argument:
 
 ```ruby
-require 'patron'
-
 transport_configuration = lambda do |f|
   f.response :logger
   f.adapter  :patron

--- a/opensearch-transport/README.md
+++ b/opensearch-transport/README.md
@@ -32,16 +32,16 @@ such as [Patron](https://github.com/toland/patron) or [Typhoeus](https://github.
 Most such HTTP libraries are used through the [Faraday](https://rubygems.org/gems/faraday) HTTP library
 and its [adapters](https://github.com/lostisland/awesome-faraday/#adapters).
 
-Just include the library's gem and adapter gem, and require the library and adapter in your code, and it will be automatically used.
+Include the library's gem and adapter gem, and require the library and adapter in your code, and it will be automatically used.
 If you don't use Bundler, you may need to require the library explicitly (like `require 'faraday/patron'`).
 
 Currently these libraries will be automatically detected and used:
 - [Patron](https://github.com/toland/patron) through [faraday-patron](https://github.com/lostisland/faraday-patron)
-- [Typhoeus](https://github.com/typhoeus/typhoeus) through [faraday-typhoeus](https://github.com/lostisland/faraday-typhoeus) or its built-in adapter.
+- [Typhoeus](https://github.com/typhoeus/typhoeus) through [faraday-typhoeus](https://github.com/lostisland/faraday-typhoeus) for Faraday 2 or higher, or its built-in adapter for Faraday 1.
 - [HTTPClient](https://rubygems.org/gems/httpclient) through [faraday-httpclient](https://github.com/lostisland/faraday-httpclient)
 - [Net::HTTP::Persistent](https://rubygems.org/gems/net-http-persistent) through [faraday-net_http_persistent](https://github.com/lostisland/faraday-net_http_persistent)
 
-**Note on [Typhoeus](https://github.com/typhoeus/typhoeus)**: You need to use v1.4.0 or up since older versions are not compatible with Faraday 1.0 or higher.
+**Note on [Typhoeus](https://github.com/typhoeus/typhoeus)**: You need to use v1.4.0 or up since older versions are not compatible with Faraday 1.0 or higher. You can't use Typhoeus with Faraday 2.0 or higher with Ruby versions less than 2.7 because [faraday-typhoeus](https://github.com/lostisland/faraday-typhoeus) doesn't support it, so use Faraday 1.x and its built-in Typhoeus adapter.
 
 **Note on [Faraday](https://rubygems.org/gems/faraday)**: If you use Faraday 2.0 or higher, if the adapter is in a separate gem, you will likely need to declare that gem as well. Only the Net::HTTP adapter gem is included by default. Faraday 1.x includes most common adapter gems already.
 

--- a/opensearch-transport/lib/opensearch/transport/client.rb
+++ b/opensearch-transport/lib/opensearch/transport/client.rb
@@ -330,14 +330,17 @@ module OpenSearch
       # @api private
       #
       def __auto_detect_adapter
+        # Get the Faraday adapter list without initializing it.
+        adapters = Faraday::Adapter.instance_variable_get(:@registered_middleware) || {}
+        # Pick an adapter that has both the client and adapter defined.
         case
-        when defined?(::Patron)
+        when defined?(::Patron) && adapters.key?(:patron)
           :patron
-        when defined?(::Typhoeus)
+        when defined?(::Typhoeus) && adapters.key?(:typhoeus)
           :typhoeus
-        when defined?(::HTTPClient)
+        when defined?(::HTTPClient) && adapters.key?(:httpclient)
           :httpclient
-        when defined?(::Net::HTTP::Persistent)
+        when defined?(::Net::HTTP::Persistent) && adapters.key?(:net_http_persistent)
           :net_http_persistent
         else
           ::Faraday.default_adapter

--- a/opensearch-transport/opensearch-transport.gemspec
+++ b/opensearch-transport/opensearch-transport.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'multi_json'
-  s.add_dependency 'faraday', '~> 1'
+  s.add_dependency 'faraday', '>= 1.0', '< 3'
 
   s.add_development_dependency 'ansi'
   s.add_development_dependency 'bundler'
@@ -70,12 +70,15 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'opensearch-ruby'
   s.add_development_dependency 'hashie'
   s.add_development_dependency 'httpclient'
+  s.add_development_dependency 'faraday-httpclient'
   s.add_development_dependency 'manticore' if defined? JRUBY_VERSION
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-reporters'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'net-http-persistent'
+  s.add_development_dependency 'faraday-net_http_persistent'
   s.add_development_dependency 'patron' unless defined? JRUBY_VERSION
+  s.add_development_dependency 'faraday-patron' unless defined? JRUBY_VERSION
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 13'
   s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
@@ -84,6 +87,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit', '~> 2'
   s.add_development_dependency 'typhoeus', '~> 1.4'
+  s.add_development_dependency 'faraday-typhoeus'
   s.add_development_dependency 'yard'
 
   s.description = <<-DESC.gsub(/^    /, '')

--- a/opensearch-transport/opensearch-transport.gemspec
+++ b/opensearch-transport/opensearch-transport.gemspec
@@ -87,7 +87,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit', '~> 2'
   s.add_development_dependency 'typhoeus', '~> 1.4'
-  s.add_development_dependency 'faraday-typhoeus'
+  s.add_development_dependency 'faraday-typhoeus' unless RUBY_VERSION.to_f < 2.7
   s.add_development_dependency 'yard'
 
   s.description = <<-DESC.gsub(/^    /, '')

--- a/opensearch-transport/spec/opensearch/transport/base_spec.rb
+++ b/opensearch-transport/spec/opensearch/transport/base_spec.rb
@@ -184,7 +184,7 @@ describe OpenSearch::Transport::Transport::Base do
 
       it 'retries on 404 status the specified number of max_retries' do
         expect do
-          client.transport.perform_request('GET', 'myindex/mydoc/1?routing=FOOBARBAZ', {}, nil, nil, retry_on_failure: 5)
+          client.transport.perform_request('GET', 'myindex/_doc/1?routing=FOOBARBAZ', {}, nil, nil, retry_on_failure: 5)
         end.to raise_exception(OpenSearch::Transport::Transport::Errors::NotFound)
       end
     end

--- a/opensearch-transport/spec/opensearch/transport/client_spec.rb
+++ b/opensearch-transport/spec/opensearch/transport/client_spec.rb
@@ -1680,12 +1680,12 @@ describe OpenSearch::Transport::Client do
           client.perform_request('DELETE', '_all')
           client.perform_request('DELETE', 'myindex') rescue
           client.perform_request('PUT', 'myindex', {}, { settings: { number_of_shards: 2, number_of_replicas: 0 } })
-          client.perform_request('PUT', 'myindex/mydoc/1', { routing: 'XYZ', timeout: '1s' }, { foo: 'bar' })
+          client.perform_request('PUT', 'myindex/_doc/1', { routing: 'XYZ', timeout: '1s' }, { foo: 'bar' })
           client.perform_request('GET', '_cluster/health?wait_for_status=green&timeout=2s', {})
         end
 
         let(:response) do
-          client.perform_request('GET', 'myindex/mydoc/1?routing=XYZ')
+          client.perform_request('GET', 'myindex/_doc/1?routing=XYZ')
         end
 
         it 'handles paths and URL paramters' do
@@ -1700,7 +1700,7 @@ describe OpenSearch::Transport::Client do
       context 'when an invalid url is specified' do
         it 'raises an exception' do
           expect {
-            client.perform_request('GET', 'myindex/mydoc/1?routing=FOOBARBAZ')
+            client.perform_request('GET', 'myindex/_doc/1?routing=FOOBARBAZ')
           }.to raise_exception(OpenSearch::Transport::Transport::Errors::NotFound)
         end
       end

--- a/opensearch-transport/spec/spec_helper.rb
+++ b/opensearch-transport/spec/spec_helper.rb
@@ -40,7 +40,11 @@ if defined?(JRUBY_VERSION)
 else
   require 'pry-byebug'
   require 'faraday/patron'
-  require 'faraday/typhoeus'
+  begin
+    require 'faraday/typhoeus'
+  rescue LoadError
+    # Only needed for Faraday 2.
+  end
   require 'opensearch/transport/transport/http/curb'
   require 'curb'
 end

--- a/opensearch-transport/spec/spec_helper.rb
+++ b/opensearch-transport/spec/spec_helper.rb
@@ -29,6 +29,8 @@ if ENV['COVERAGE'] && ENV['CI'].nil?
 end
 
 require 'opensearch-transport'
+require 'faraday/httpclient'
+require 'faraday/net_http_persistent'
 require 'logger'
 require 'ansi/code'
 require 'hashie/mash'
@@ -37,6 +39,8 @@ if defined?(JRUBY_VERSION)
   require 'pry-nav'
 else
   require 'pry-byebug'
+  require 'faraday/patron'
+  require 'faraday/typhoeus'
   require 'opensearch/transport/transport/http/curb'
   require 'curb'
 end

--- a/opensearch-transport/test/integration/transport_test.rb
+++ b/opensearch-transport/test/integration/transport_test.rb
@@ -34,8 +34,14 @@ class OpenSearch::Transport::ClientIntegrationTest < Minitest::Test
     end
 
     should "allow to customize the Faraday adapter to Typhoeus" do
+      # Require the library so autodetection finds it.
       require 'typhoeus'
-      require 'typhoeus/adapters/faraday'
+      # Require the adapter so autodetection finds it.
+      begin
+        require 'faraday/typhoeus'
+      rescue LoadError
+        # Only needed for Faraday 2.
+      end
 
       transport = OpenSearch::Transport::Transport::HTTP::Faraday.new \
         :hosts => [ { host: @host, port: @port } ] do |f|
@@ -48,7 +54,10 @@ class OpenSearch::Transport::ClientIntegrationTest < Minitest::Test
     end unless jruby?
 
     should "allow to customize the Faraday adapter to NetHttpPersistent" do
+      # Require the library so autodetection finds it.
       require 'net/http/persistent'
+      # Require the adapter so autodetection finds it.
+      require 'faraday/net_http_persistent'
 
       transport = OpenSearch::Transport::Transport::HTTP::Faraday.new \
                                                                        :hosts => [ { host: @host, port: @port } ] do |f|


### PR DESCRIPTION
- Support Faraday 1.x and 2.x in opensearch-transport.
- Made client autodetection not break if the detected HTTP client is
  there but the associated Faraday adapter is not.
- Made the test setup require the referenced adapters.
- Made it more clear in the README that Faraday uses adapters.
- Backported minor test fixes from opensearch-transport 2.

[Fixes #59]

### Description

This makes it possible to use opensearch-transport with Faraday 1 or 2.

### Issues Resolved

Closes [#59] for  opensearch-transport 1.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
