### PR TITLE
Use safe_load instead of load for yaml

### DIFF
--- a/opensearch/lib/opensearch.rb
+++ b/opensearch/lib/opensearch.rb
@@ -65,7 +65,7 @@ module OpenSearch
 
       body = if response.headers['content-type'] == 'application/yaml'
                require 'yaml'
-               YAML.load(response.body)
+               YAML.safe_load(response.body)
              else
                response.body
              end

--- a/profile/benchmarking.rb
+++ b/profile/benchmarking.rb
@@ -79,7 +79,7 @@ module OpenSearch
     def each_run(file)
       if file
         file = File.new(file)
-        matrix = YAML.load(ERB.new(file.read).result)
+        matrix = YAML.safe_load(ERB.new(file.read).result)
         file.close
 
         matrix.each_with_index do |run, i|


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Using `safe_load` instead of `load` for YAML.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
