### PR TITLE
Bumping opensearch ruby gem version to 2.0.1

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -19,9 +19,9 @@ The below matrix shows the compatibility of the [`opensearch-ruby`](https://ruby
 | 1.3.1 | 1.0.0 |
 | 1.3.2 | 1.0.0 |
 | 1.3.3 | 1.0.0 |
-| 2.0.0 | 2.0.0 |
-| 2.0.1 | 2.0.0 |
+| 2.0.0 | 2.0.1 |
+| 2.0.1 | 2.0.1 |
 
 ## Upgrading
 
-Major versions of OpenSearch introduce breaking changes that require careful upgrades of the client. While `opensearch-ruby-client` 2.0.0 works against the latest OpenSearch 1.x, certain deprecated features removed in OpenSearch 2.0 have also been removed from the client. Please refer to the [OpenSearch documentation](https://opensearch.org/docs/latest/clients/index/) for more information.
+Major versions of OpenSearch introduce breaking changes that require careful upgrades of the client. While `opensearch-ruby-client` 2.0.1 works against the latest OpenSearch 1.x, certain deprecated features removed in OpenSearch 2.0 have also been removed from the client. Please refer to the [OpenSearch documentation](https://opensearch.org/docs/latest/clients/index/) for more information.

--- a/opensearch-api/lib/opensearch/api/version.rb
+++ b/opensearch-api/lib/opensearch/api/version.rb
@@ -26,6 +26,6 @@
 
 module OpenSearch
   module API
-    VERSION = '2.0.0'.freeze
+    VERSION = '2.0.1'.freeze
   end
 end

--- a/opensearch/lib/opensearch/version.rb
+++ b/opensearch/lib/opensearch/version.rb
@@ -25,5 +25,5 @@
 # under the License.
 
 module OpenSearch
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end

--- a/opensearch/opensearch.gemspec
+++ b/opensearch/opensearch.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'opensearch-transport', '2.0.0'
-  s.add_dependency 'opensearch-api',       '2.0.0'
+  s.add_dependency 'opensearch-api',       '2.0.1'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'byebug' unless defined?(JRUBY_VERSION) || defined?(Rubinius)


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Bump ruby gem version to 2.0.1 for opensearch and opensearch-api.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
