### PR TITLE
Remove deprecated escape_utils. (#74)

### DIFF
--- a/opensearch-api/lib/opensearch/api/utils.rb
+++ b/opensearch-api/lib/opensearch/api/utils.rb
@@ -40,7 +40,7 @@ module OpenSearch
       # @api private
       def __escape(string)
         return string if string == '*'
-        defined?(EscapeUtils) ? EscapeUtils.escape_url(string.to_s) : CGI.escape(string.to_s)
+        CGI.escape(string.to_s)
       end
 
       # Create a "list" of values from arguments, ignoring nil values and encoding special characters.

--- a/opensearch-api/opensearch-api.gemspec
+++ b/opensearch-api/opensearch-api.gemspec
@@ -79,7 +79,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'hashie'
 
   s.add_development_dependency 'cane'
-  s.add_development_dependency 'escape_utils' unless defined? JRUBY_VERSION
   s.add_development_dependency 'jbuilder'
   s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'simplecov'

--- a/opensearch-api/spec/opensearch/api/utils_spec.rb
+++ b/opensearch-api/spec/opensearch/api/utils_spec.rb
@@ -48,15 +48,8 @@ describe OpenSearch::API::Utils do
       expect(utils.__escape('*')).to eq('*')
     end
 
-    it 'users CGI.escape by default' do
+    it 'uses CGI.escape by default' do
       expect(CGI).to receive(:escape).and_call_original
-      expect(utils.__escape('foo bar')).to eq('foo+bar')
-    end
-
-    it 'uses the escape_utils gem when available', unless: defined?(JRUBY_VERSION) do
-      require 'escape_utils'
-      expect(CGI).not_to receive(:escape)
-      expect(EscapeUtils).to receive(:escape_url).and_call_original
       expect(utils.__escape('foo bar')).to eq('foo+bar')
     end
   end


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>
(cherry picked from commit 7ab1830c16f36cc090a8bd1fe42500ecdc3de283)

### Description
Backport #74 to 2.0

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
