### PR TITLE
[Backport 1.x] Remove deprecated escape_utils, and test fixes

### DIFF
--- a/opensearch-api/lib/opensearch/api/utils.rb
+++ b/opensearch-api/lib/opensearch/api/utils.rb
@@ -40,7 +40,7 @@ module OpenSearch
       # @api private
       def __escape(string)
         return string if string == '*'
-        defined?(EscapeUtils) ? EscapeUtils.escape_url(string.to_s) : CGI.escape(string.to_s)
+        CGI.escape(string.to_s)
       end
 
       # Create a "list" of values from arguments, ignoring nil values and encoding special characters.

--- a/opensearch-api/opensearch-api.gemspec
+++ b/opensearch-api/opensearch-api.gemspec
@@ -79,7 +79,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'hashie'
 
   s.add_development_dependency 'cane'
-  s.add_development_dependency 'escape_utils' unless defined? JRUBY_VERSION
   s.add_development_dependency 'jbuilder'
   s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'simplecov'

--- a/opensearch-api/spec/opensearch/api/utils_spec.rb
+++ b/opensearch-api/spec/opensearch/api/utils_spec.rb
@@ -48,15 +48,8 @@ describe OpenSearch::API::Utils do
       expect(utils.__escape('*')).to eq('*')
     end
 
-    it 'users CGI.escape by default' do
+    it 'uses CGI.escape by default' do
       expect(CGI).to receive(:escape).and_call_original
-      expect(utils.__escape('foo bar')).to eq('foo+bar')
-    end
-
-    it 'uses the escape_utils gem when available', unless: defined?(JRUBY_VERSION) do
-      require 'escape_utils'
-      expect(CGI).not_to receive(:escape)
-      expect(EscapeUtils).to receive(:escape_url).and_call_original
       expect(utils.__escape('foo bar')).to eq('foo+bar')
     end
   end

--- a/opensearch-transport/spec/opensearch/transport/base_spec.rb
+++ b/opensearch-transport/spec/opensearch/transport/base_spec.rb
@@ -184,7 +184,7 @@ describe OpenSearch::Transport::Transport::Base do
 
       it 'retries on 404 status the specified number of max_retries' do
         expect do
-          client.transport.perform_request('GET', 'myindex/mydoc/1?routing=FOOBARBAZ', {}, nil, nil, retry_on_failure: 5)
+          client.transport.perform_request('GET', 'myindex/_doc/1?routing=FOOBARBAZ', {}, nil, nil, retry_on_failure: 5)
         end.to raise_exception(OpenSearch::Transport::Transport::Errors::NotFound)
       end
     end

--- a/opensearch-transport/spec/opensearch/transport/client_spec.rb
+++ b/opensearch-transport/spec/opensearch/transport/client_spec.rb
@@ -1680,12 +1680,12 @@ describe OpenSearch::Transport::Client do
           client.perform_request('DELETE', '_all')
           client.perform_request('DELETE', 'myindex') rescue
           client.perform_request('PUT', 'myindex', {}, { settings: { number_of_shards: 2, number_of_replicas: 0 } })
-          client.perform_request('PUT', 'myindex/mydoc/1', { routing: 'XYZ', timeout: '1s' }, { foo: 'bar' })
+          client.perform_request('PUT', 'myindex/_doc/1', { routing: 'XYZ', timeout: '1s' }, { foo: 'bar' })
           client.perform_request('GET', '_cluster/health?wait_for_status=green&timeout=2s', {})
         end
 
         let(:response) do
-          client.perform_request('GET', 'myindex/mydoc/1?routing=XYZ')
+          client.perform_request('GET', 'myindex/_doc/1?routing=XYZ')
         end
 
         it 'handles paths and URL paramters' do
@@ -1700,7 +1700,7 @@ describe OpenSearch::Transport::Client do
       context 'when an invalid url is specified' do
         it 'raises an exception' do
           expect {
-            client.perform_request('GET', 'myindex/mydoc/1?routing=FOOBARBAZ')
+            client.perform_request('GET', 'myindex/_doc/1?routing=FOOBARBAZ')
           }.to raise_exception(OpenSearch::Transport::Transport::Errors::NotFound)
         end
       end


### PR DESCRIPTION
### Description
Fixes tests in 1.x by backporting fixes from 2.0.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
