### PR TITLE
Ruby 2.6 works with faraday-typhoeus now

### DIFF
--- a/opensearch-transport/Gemfile
+++ b/opensearch-transport/Gemfile
@@ -37,7 +37,6 @@ if File.exist? File.expand_path('../opensearch/opensearch.gemspec', __dir__)
   gem 'opensearch-ruby', path: File.expand_path('../opensearch', __dir__), require: false
 end
 
-ENV['FARADAY_VERSION'] = '~> 1.0' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
 gem 'faraday', ENV['FARADAY_VERSION'], require: false if ENV.key?('FARADAY_VERSION')
 
 group :development, :test do

--- a/opensearch-transport/README.md
+++ b/opensearch-transport/README.md
@@ -37,11 +37,11 @@ If you don't use Bundler, you may need to require the library explicitly (like `
 
 Currently these libraries will be automatically detected and used:
 - [Patron](https://github.com/toland/patron) through [faraday-patron](https://github.com/lostisland/faraday-patron)
-- [Typhoeus](https://github.com/typhoeus/typhoeus) through [faraday-typhoeus](https://github.com/dleavitt/faraday-typhoeus) for Faraday 2 or higher, or its built-in adapter for Faraday 1.
+- [Typhoeus](https://github.com/typhoeus/typhoeus) through [faraday-typhoeus](https://github.com/dleavitt/faraday-typhoeus) for Faraday 2 or higher, or Faraday's built-in adapter for Faraday 1.
 - [HTTPClient](https://rubygems.org/gems/httpclient) through [faraday-httpclient](https://github.com/lostisland/faraday-httpclient)
 - [Net::HTTP::Persistent](https://rubygems.org/gems/net-http-persistent) through [faraday-net_http_persistent](https://github.com/lostisland/faraday-net_http_persistent)
 
-**Note on [Typhoeus](https://github.com/typhoeus/typhoeus)**: You need to use v1.4.0 or up since older versions are not compatible with Faraday 1.0 or higher. You can't use Typhoeus with Faraday 2.0 or higher with Ruby versions less than 2.7 because [faraday-typhoeus](https://github.com/dleavitt/faraday-typhoeus) doesn't support it, so use Faraday 1.x and its built-in Typhoeus adapter.
+**Note on [Typhoeus](https://github.com/typhoeus/typhoeus)**: You need to use v1.4.0 or up since older versions are not compatible with Faraday 1.0 or higher.
 
 **Note on [Faraday](https://rubygems.org/gems/faraday)**: If you use Faraday 2.0 or higher, if the adapter is in a separate gem, you will likely need to declare that gem as well. Only the Net::HTTP adapter gem is included by default. Faraday 1.x includes most common adapter gems already.
 

--- a/opensearch-transport/opensearch-transport.gemspec
+++ b/opensearch-transport/opensearch-transport.gemspec
@@ -87,7 +87,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit', '~> 2'
   s.add_development_dependency 'typhoeus', '~> 1.4'
-  s.add_development_dependency 'faraday-typhoeus' if !ENV.key?('FARADAY_VERSION') && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
+  s.add_development_dependency 'faraday-typhoeus' if !ENV.key?('FARADAY_VERSION') && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
   s.add_development_dependency 'yard'
 
   s.description = <<-DESC.gsub(/^    /, '')

--- a/opensearch-transport/spec/opensearch/transport/client_spec.rb
+++ b/opensearch-transport/spec/opensearch/transport/client_spec.rb
@@ -247,7 +247,7 @@ describe OpenSearch::Transport::Client do
       end unless jruby?
     end
 
-    context 'when the adapter is patron' do
+    context 'when the adapter is patron', unless: jruby? do
       let(:adapter) do
         client.transport.connections.all.first.connection.builder.adapter
       end
@@ -275,7 +275,7 @@ describe OpenSearch::Transport::Client do
       end
     end unless jruby?
 
-    context 'when the adapter is specified as a string key' do
+    context 'when the adapter is specified as a string key', unless: jruby? do
       let(:adapter) do
         client.transport.connections.all.first.connection.builder.adapter
       end
@@ -305,7 +305,7 @@ describe OpenSearch::Transport::Client do
       end
     end
 
-    context 'when the Faraday adapter is configured' do
+    context 'when the Faraday adapter is configured', unless: jruby? do
 
       let(:client) do
         described_class.new do |faraday|

--- a/opensearch-transport/test/integration/transport_test.rb
+++ b/opensearch-transport/test/integration/transport_test.rb
@@ -46,7 +46,11 @@ class OpenSearch::Transport::ClientIntegrationTest < Minitest::Test
         end
 
       client = OpenSearch::Transport::Client.new transport: transport
-      client.perform_request 'GET', ''
+      response = client.perform_request 'GET', ''
+
+      assert_respond_to(response.body, :to_hash)
+      assert_not_nil response.body['name']
+      assert_equal 'application/json; charset=UTF-8', response.headers['content-type']
     end unless jruby?
 
     should "allow to customize the Faraday adapter to NetHttpPersistent" do


### PR DESCRIPTION
### Description
Ruby 2.6 (and JRuby 9.3) works with faraday-typhoeus now. Gemfile restrictions and README adjusted accordingly. No app changes. Adjusted some Patron test restrictions which were hidden before because Faraday 2 wasn't being tested with JRuby, due to the old faraday-typhoeus version restriction.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
