### PR TITLE
Bumping version to 2.0.1 for opensearch-transport

### DIFF
--- a/opensearch-transport/lib/opensearch/transport/version.rb
+++ b/opensearch-transport/lib/opensearch/transport/version.rb
@@ -26,6 +26,6 @@
 
 module OpenSearch
   module Transport
-    VERSION = '2.0.0'.freeze
+    VERSION = '2.0.1'.freeze
   end
 end

--- a/opensearch/lib/opensearch/version.rb
+++ b/opensearch/lib/opensearch/version.rb
@@ -25,5 +25,5 @@
 # under the License.
 
 module OpenSearch
-  VERSION = '2.0.2'.freeze
+  VERSION = '2.0.3'.freeze
 end

--- a/opensearch/opensearch.gemspec
+++ b/opensearch/opensearch.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4'
 
-  s.add_dependency 'opensearch-transport', '2.0.0'
+  s.add_dependency 'opensearch-transport', '~> 2.0.0'
   s.add_dependency 'opensearch-api',       '2.0.2'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Bumping version to 2.0.1 for opensearch-transport.

### Issues Resolved
#91 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
