### PR TITLE
Adds inclusive naming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @VijayanB @jayeshathila @robsears @vamshin @dblock @VachaShah @nhtruong
+# This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
+*   @opensearch-project/clients @robsears

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -47,8 +47,6 @@ jobs:
         run: cd opensearch-api && bundle exec rake test:spec
       - name: opensearch-dsl
         run: cd opensearch-dsl && bundle exec rake test:all
-      - name: opensearch-aws-sigv4
-        run: cd opensearch-aws-sigv4 && bundle exec rake test:all
 
 
   test-opensearch-security:
@@ -83,5 +81,5 @@ jobs:
           ruby -v
           rake bundle:clean
           rake bundle:install
-      - name: opensearch-ruby
+      - name: opensearch
         run: cd opensearch && bundle exec rake test_security:all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,6 @@ jobs:
         run: cd opensearch-api && bundle exec rake test:spec
       - name: opensearch-dsl
         run: cd opensearch-dsl && bundle exec rake test:all
-      - name: opensearch-aws-sigv4
-        run: cd opensearch-aws-sigv4 && bundle exec rake test:all
 
   test-opensearch-faraday-1:
     env:
@@ -120,5 +118,5 @@ jobs:
           ruby -v
           rake bundle:clean
           rake bundle:install
-      - name: opensearch-ruby
+      - name: opensearch
         run: cd opensearch && bundle exec rake test_security:all

--- a/.github/workflows/test-unreleased.yml
+++ b/.github/workflows/test-unreleased.yml
@@ -62,5 +62,3 @@ jobs:
         run: cd opensearch-api && bundle exec rake test:spec
       - name: opensearch-dsl
         run: cd opensearch-dsl && bundle exec rake test:all
-      - name: opensearch-aws-sigv4
-        run: cd opensearch-aws-sigv4 && bundle exec rake test:all

--- a/ADMINS.md
+++ b/ADMINS.md
@@ -1,4 +1,6 @@
-# OpenSearch Ruby Client Admins
+## Overview
+
+This document explains who the admins are (see below), what they do in this repo, and how they should be doing it. If you're interested in becoming a maintainer, see [MAINTAINERS](MAINTAINERS.md). If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Current Admins
 
@@ -11,5 +13,20 @@
 | Yuvraj Jaiswal           | [yuvi17](https://github.com/yuvi17)                 | Amazon      |
 
 
-[This document](https://github.com/opensearch-project/.github/blob/main/ADMINS.md)
-explains what an admin's responsibilities are.
+## Admin Responsibilities
+
+As an admin you own stewartship of the repository and its settings. Admins have [admin-level permissions on a repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization). Use those privileges to serve the community and protect the repository as follows.
+
+### Prioritize Security
+
+Security is your number one priority. Manage security keys and safeguard access to the repository.
+
+Note that this repository is monitored and supported 24/7 by Amazon Security, see [Reporting a Vulnerability](SECURITY.md) for details.
+
+### Enforce Code of Conduct
+
+Act on [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) violations by revoking access, and blocking malicious actors.
+
+### Adopt Organizational Best Practices
+
+Adopt organizational best practices, work in the open, and collaborate with other admins by opening issues before making process changes. Prefer consistency, and avoid diverging from practices in the opensearch-project organization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added Sigv4 Support with `opensearch-aws-sigv4` gem ([#71](https://github.com/opensearch-project/opensearch-ruby/issues/71))
 
 ### Changed
+- Updated for inclusive naming ([#99](https://github.com/opensearch-project/opensearch-ruby/issues/99))
+
 
 ### Deprecated
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,10 @@
 - [Ways to Contribute](#ways-to-contribute)
   - [Bug Reports](#bug-reports)
   - [Feature Requests](#feature-requests)
+  - [Documentation Changes](#documentation-changes)
   - [Contributing Code](#contributing-code)
 - [Developer Certificate of Origin](#developer-certificate-of-origin)
 - [License Headers](#license-headers)
-  - [Java](#java)
-  - [Python, Ruby, Shell](#python-ruby-shell)
-  - [Shell](#shell)
-- [Changelog](#changelog)
-  - [Adding Changes](#adding-changes)
 - [Review Process](#review-process)
 
 ## Contributing to OpenSearch
@@ -100,46 +96,20 @@ New files in your code contributions should contain the following license header
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
-*/
+ */
 ```
 
-### Python, Ruby, Shell
+### Python
 ```
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
-#
-# The OpenSearch Contributors require contributions made to
-# this file be licensed under the Apache-2.0 license or a
-# compatible open source license.
 ```
-
 
 ### Shell
 ```
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 ```
-
-## Changelog
-
-OpenSearch-ruby maintains a version specific changelog by enforcing a change to the ongoing [CHANGELOG](CHANGELOG.md) file adhering to the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
-
-The changes are curated by version, with the changes to the main branch added chronologically to the `Unreleased` version. Each version has corresponding sections which list out the category of the change - `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
-
-
-### Adding Changes
-
-As a contributor, you must ensure that every pull request has its changes listed out within the corresponding version and appropriate section of the [CHANGELOG](CHANGELOG.md) file.
-
-Adding in the change is a two step process -
-1. Add your changes to the corresponding section within the CHANGELOG file with dummy pull request information, publish the PR.
-
-2. Update the entry for your change in [`CHANGELOG.md`](CHANGELOG.md) and make sure that you reference the pull request there.
 
 ## Review Process
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,23 +1,78 @@
-# OpenSearch Ruby Client Maintainers
+- [Overview](#overview)
+- [Current Maintainers](#current-maintainers)
+- [Maintainer Responsibilities](#maintainer-responsibilities)
+  - [Uphold Code of Conduct](#uphold-code-of-conduct)
+  - [Prioritize Security](#prioritize-security)
+  - [Review Pull Requests](#review-pull-requests)
+  - [Triage Open Issues](#triage-open-issues)
+  - [Backports](#backports)
+  - [Be Responsive](#be-responsive)
+  - [Maintain Overall Health of the Repo](#maintain-overall-health-of-the-repo)
+  - [Use Semver](#use-semver)
+  - [Release Frequently](#release-frequently)
+  - [Promote Other Maintainers](#promote-other-maintainers)
+  
+## Overview
+
+This document explains who the maintainers are (see below), what they do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Current Maintainers
 
-| Maintainer              | GitHub ID                                       | Affiliation |
-|-------------------------|-------------------------------------------------|-------------|
-| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)         | Amazon      |
-| Jayesh Hathila          | [jayeshathila](https://github.com/jayeshathila) | Amazon      |
-| Rob Sears               | [robsears](https://github.com/robsears)         | Bonsai      |
-| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)           | Amazon      |
-| Daniel Doubrovkine      | [dblock](https://github.com/dblock)             | Amazon      |
-| Vacha Shah              | [VachaShah](https://github.com/VachaShah)       | Amazon      |
-| Theo Truong             | [nhtruong](https://github.com/nhtruong)         | Amazon      |
+| Maintainer               | GitHub ID                                       | Affiliation |
+| ------------------------ | ---------------------------------------         | ----------- |
+| Vijayan Balasubramanian  | [VijayanB](https://github.com/VijayanB)         |   Amazon    |
+| Jayesh Hathila           | [jayeshathila](https://github.com/jayeshathila) |   Amazon    |
+| Rob Sears                | [robsears](https://github.com/robsears)         |   Bonsai    |
+| Vamshi Vijay Nakkirtha   | [vamshin](https://github.com/vamshin)           |   Amazon    |
+| Yuvraj Jaiswal           | [yuvi17](https://github.com/yuvi17)             |   Amazon    |
 
-## Emeritus
+## Maintainer Responsibilities
 
-| Maintainer              | GitHub ID                                       | Affiliation |
-|-------------------------|-------------------------------------------------|-------------|
-| Yuvraj Jaiswal          | [yuvi17](https://github.com/yuvi17)             | Amazon      |
+Maintainers are active and visible members of the community, and have [maintain-level permissions on a repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization). Use those privileges to serve the community and evolve code as follows.
 
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md)
-explains what maintainers do in this repo, and how they should be doing it.
-If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+### Uphold Code of Conduct
+
+Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers and admins.
+
+### Prioritize Security
+
+Security is your number one priority. Maintainer's Github keys must be password protected securely and any reported security vulnerabilities are addressed before features or bugs.
+
+Note that this repository is monitored and supported 24/7 by Amazon Security, see [Reporting a Vulnerability](SECURITY.md) for details.
+
+### Review Pull Requests
+
+Review pull requests regularly, comment, suggest, reject, merge and close. Accept only high quality pull-requests. Provide code reviews and guidance on incomming pull requests. Don't let PRs be stale and do your best to be helpful to contributors.
+
+### Triage Open Issues
+
+Manage labels, review issues regularly, and triage by labelling them. 
+
+All repositories in this organization have a standard set of labels, including `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `blocker`, `invalid`, `question`, `wontfix`, and `untriaged`, along with release labels, such as `v1.0.0`, `v1.1.0`, `v2.0.0`, `patch`, and `backport`.
+
+Use labels to target an issue or a PR for a given release, add `help wanted` to good issues for new community members, and `blocker` for issues that scare you or need immediate attention. Request for more information from a submitter if an issue is not clear. Create new labels as needed by the project.
+
+### Backports
+
+The Github workflow in [backport.yml](.github/workflows/backport.yml) creates backport PRs automatically when the original PR with an appropriate label `backport <backport-branch-name>` is merged to main. To backport a PR to `1.x`, add a label `backport 1.x` to the PR, once this PR is merged to main, the workflow will create a backport PR to the `1.x` branch.
+
+### Be Responsive
+
+Respond to enhancement requests, and forum posts. Allocate time to reviewing and commenting on issues and conversations as they come in. 
+
+### Maintain Overall Health of the Repo
+
+Keep the `main` branch at production quality at all times. Backport features as needed. Cut release branches and tags to enable future patches. 
+
+### Use Semver
+
+Use and enforce [semantic versioning](https://semver.org/) and do not let breaking changes be made outside of major releases.
+
+### Release Frequently
+
+Make frequent project releases to the community.
+
+### Promote Other Maintainers
+
+Assist, add, and remove [MAINTAINERS](MAINTAINERS.md). Exercise good judgement, and propose high quality contributors to become co-maintainers.
+

--- a/Rakefile
+++ b/Rakefile
@@ -54,14 +54,12 @@ SUBPROJECTS = [
   'opensearch-transport',
   'opensearch-dsl',
   'opensearch-api',
-  'opensearch-aws-sigv4',
 ].freeze
 
 RELEASE_TOGETHER = [
   'opensearch',
   'opensearch-transport',
   'opensearch-api',
-  'opensearch-aws-sigv4',
 ].freeze
 
 CERT_DIR = ENV['CERT_DIR']

--- a/opensearch-api/lib/opensearch/api/actions/cat/aliases.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/aliases.rb
@@ -32,7 +32,7 @@ module OpenSearch
         #
         # @option arguments [List] :name A comma-separated list of alias names to return
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by

--- a/opensearch-api/lib/opensearch/api/actions/cat/allocation.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/allocation.rb
@@ -34,8 +34,7 @@ module OpenSearch
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values (options: b, k, kb, m, mb, g, gb, t, tb, p, pb)
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information

--- a/opensearch-api/lib/opensearch/api/actions/cat/allocation.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/allocation.rb
@@ -33,8 +33,10 @@ module OpenSearch
         # @option arguments [List] :node_id A comma-separated list of node IDs or names to limit the returned information
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values (options: b, k, kb, m, mb, g, gb, t, tb, p, pb)
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
@@ -70,6 +72,7 @@ module OpenSearch
           :bytes,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :s,

--- a/opensearch-api/lib/opensearch/api/actions/cat/cluster_manager.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/cluster_manager.rb
@@ -6,34 +6,17 @@
 #
 # Modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
-#
-# Licensed to Elasticsearch B.V. under one or more contributor
-# license agreements. See the NOTICE file distributed with
-# this work for additional information regarding copyright
-# ownership. Elasticsearch B.V. licenses this file to you under
-# the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+
         
-# <b>DEPRECATED:</b> Please use <tt>cluster_manager</tt> instead.
 module OpenSearch
   module API
     module Cat
       module Actions
-        # Returns information about the master node.
+        # Returns information about the cluster_manager node.
         #
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
@@ -41,13 +24,13 @@ module OpenSearch
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
-        def master(arguments = {})
+        def cluster_manager(arguments = {})
           headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
           method = OpenSearch::API::HTTP_GET
-          path   = "_cat/master"
+          path   = "_cat/cluster_manager"
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -57,10 +40,10 @@ module OpenSearch
         # Register this action with its valid params when the module is loaded.
         #
         # @since 6.2.0
-        ParamsRegistry.register(:master, [
+        ParamsRegistry.register(:cluster_manager, [
           :format,
           :local,
-          :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :s,

--- a/opensearch-api/lib/opensearch/api/actions/cat/indices.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/indices.rb
@@ -33,8 +33,10 @@ module OpenSearch
         # @option arguments [List] :index A comma-separated list of index names to limit the returned information
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values (options: b, k, kb, m, mb, g, gb, t, tb, p, pb)
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false) *Deprecated*
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false) *Deprecated*
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [String] :health A health status ("green", "yellow", or "red" to filter only indices matching the specified health status (options: green, yellow, red)
         # @option arguments [Boolean] :help Return help information
@@ -75,6 +77,7 @@ module OpenSearch
           :bytes,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :health,
           :help,

--- a/opensearch-api/lib/opensearch/api/actions/cat/indices.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/indices.rb
@@ -33,9 +33,8 @@ module OpenSearch
         # @option arguments [List] :index A comma-separated list of index names to limit the returned information
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values (options: b, k, kb, m, mb, g, gb, t, tb, p, pb)
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false) *Deprecated*
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false) 
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [String] :health A health status ("green", "yellow", or "red" to filter only indices matching the specified health status (options: green, yellow, red)

--- a/opensearch-api/lib/opensearch/api/actions/cat/master.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/master.rb
@@ -24,7 +24,7 @@
 # specific language governing permissions and limitations
 # under the License.
         
-# <b>DEPRECATED:</b> Please use <tt>cluster_manager</tt> instead.
+# @deprecated Please use cluster_manager instead.
 module OpenSearch
   module API
     module Cat

--- a/opensearch-api/lib/opensearch/api/actions/cat/nodeattrs.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/nodeattrs.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information

--- a/opensearch-api/lib/opensearch/api/actions/cat/nodeattrs.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/nodeattrs.rb
@@ -31,8 +31,10 @@ module OpenSearch
         # Returns information about custom node attributes.
         #
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
@@ -60,6 +62,7 @@ module OpenSearch
           :format,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :s,

--- a/opensearch-api/lib/opensearch/api/actions/cat/nodes.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/nodes.rb
@@ -33,8 +33,10 @@ module OpenSearch
         # @option arguments [String] :bytes The unit in which to display byte values (options: b, k, kb, m, mb, g, gb, t, tb, p, pb)
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [Boolean] :full_id Return the full node ID instead of the shortened version (default: false)
-        # @option arguments [Boolean] :local Calculate the selected nodes using the local cluster state rather than the state from master node (default: false) *Deprecated*
+        # @option arguments [Boolean] :local Calculate the selected nodes using the local cluster state rather than the state from cluster_manager node (default: false) *Deprecated*
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
@@ -67,6 +69,7 @@ module OpenSearch
           :full_id,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :s,

--- a/opensearch-api/lib/opensearch/api/actions/cat/nodes.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/nodes.rb
@@ -34,8 +34,7 @@ module OpenSearch
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [Boolean] :full_id Return the full node ID instead of the shortened version (default: false)
         # @option arguments [Boolean] :local Calculate the selected nodes using the local cluster state rather than the state from cluster_manager node (default: false) *Deprecated*
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information

--- a/opensearch-api/lib/opensearch/api/actions/cat/pending_tasks.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/pending_tasks.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information

--- a/opensearch-api/lib/opensearch/api/actions/cat/pending_tasks.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/pending_tasks.rb
@@ -31,8 +31,10 @@ module OpenSearch
         # Returns a concise representation of the cluster pending tasks.
         #
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
@@ -62,6 +64,7 @@ module OpenSearch
           :format,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :s,

--- a/opensearch-api/lib/opensearch/api/actions/cat/plugins.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/plugins.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information

--- a/opensearch-api/lib/opensearch/api/actions/cat/plugins.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/plugins.rb
@@ -31,8 +31,10 @@ module OpenSearch
         # Returns information about installed plugins across nodes node.
         #
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [Boolean] :include_bootstrap Include bootstrap plugins in the response
@@ -61,6 +63,7 @@ module OpenSearch
           :format,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :include_bootstrap,

--- a/opensearch-api/lib/opensearch/api/actions/cat/repositories.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/repositories.rb
@@ -32,8 +32,10 @@ module OpenSearch
         # Returns information about snapshot repositories registered in the cluster.
         #
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
@@ -61,6 +63,7 @@ module OpenSearch
           :format,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :s,

--- a/opensearch-api/lib/opensearch/api/actions/cat/repositories.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/repositories.rb
@@ -33,8 +33,7 @@ module OpenSearch
         #
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information

--- a/opensearch-api/lib/opensearch/api/actions/cat/shards.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/shards.rb
@@ -34,8 +34,7 @@ module OpenSearch
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values (options: b, k, kb, m, mb, g, gb, t, tb, p, pb)
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false) *Deprecated*
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information

--- a/opensearch-api/lib/opensearch/api/actions/cat/shards.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/shards.rb
@@ -33,8 +33,10 @@ module OpenSearch
         # @option arguments [List] :index A comma-separated list of index names to limit the returned information
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values (options: b, k, kb, m, mb, g, gb, t, tb, p, pb)
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false) *Deprecated*
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false) *Deprecated*
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
@@ -71,6 +73,7 @@ module OpenSearch
           :bytes,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :s,

--- a/opensearch-api/lib/opensearch/api/actions/cat/snapshots.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/snapshots.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [List] :repository Name of repository from which to fetch the snapshot information
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [Boolean] :ignore_unavailable Set to true to ignore unavailable snapshots
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
@@ -68,6 +70,7 @@ module OpenSearch
           :format,
           :ignore_unavailable,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :s,

--- a/opensearch-api/lib/opensearch/api/actions/cat/snapshots.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/snapshots.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [List] :repository Name of repository from which to fetch the snapshot information
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [Boolean] :ignore_unavailable Set to true to ignore unavailable snapshots
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information

--- a/opensearch-api/lib/opensearch/api/actions/cat/templates.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/templates.rb
@@ -32,8 +32,10 @@ module OpenSearch
         #
         # @option arguments [String] :name A pattern that returned template names must match
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
@@ -67,6 +69,7 @@ module OpenSearch
           :format,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :s,

--- a/opensearch-api/lib/opensearch/api/actions/cat/templates.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/templates.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :name A pattern that returned template names must match
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information

--- a/opensearch-api/lib/opensearch/api/actions/cat/thread_pool.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/thread_pool.rb
@@ -35,8 +35,7 @@ module OpenSearch
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :size The multiplier in which to display values *Deprecated* (options: , k, m, g, t, p)
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information

--- a/opensearch-api/lib/opensearch/api/actions/cat/thread_pool.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cat/thread_pool.rb
@@ -34,8 +34,10 @@ module OpenSearch
         # @option arguments [List] :thread_pool_patterns A comma-separated list of regular-expressions to filter the thread pools in the output
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :size The multiplier in which to display values *Deprecated* (options: , k, m, g, t, p)
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
@@ -71,6 +73,7 @@ module OpenSearch
           :size,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :h,
           :help,
           :s,

--- a/opensearch-api/lib/opensearch/api/actions/cluster/delete_component_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/delete_component_template.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -58,7 +60,8 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:delete_component_template, [
           :timeout,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/cluster/delete_component_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/delete_component_template.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/cluster/exists_component_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/exists_component_template.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Returns information about whether a particular component template exist
         #
         # @option arguments [String] :name The name of the template
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/cluster/exists_component_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/exists_component_template.rb
@@ -31,8 +31,10 @@ module OpenSearch
         # Returns information about whether a particular component template exist
         #
         # @option arguments [String] :name The name of the template
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -60,6 +62,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:exists_component_template, [
           :master_timeout,
+          :cluster_manager_timeout,
           :local
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/cluster/get_component_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/get_component_template.rb
@@ -31,8 +31,10 @@ module OpenSearch
         # Returns one or more component templates
         #
         # @option arguments [List] :name The comma separated names of the component templates
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -60,6 +62,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:get_component_template, [
           :master_timeout,
+          :cluster_manager_timeout,
           :local
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/cluster/get_component_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/get_component_template.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Returns one or more component templates
         #
         # @option arguments [List] :name The comma separated names of the component templates
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/cluster/get_settings.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/get_settings.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Returns cluster settings.
         #
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :include_defaults Whether to return all default clusters setting.

--- a/opensearch-api/lib/opensearch/api/actions/cluster/get_settings.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/get_settings.rb
@@ -31,7 +31,9 @@ module OpenSearch
         # Returns cluster settings.
         #
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :include_defaults Whether to return all default clusters setting.
         # @option arguments [Hash] :headers Custom HTTP headers
@@ -56,6 +58,7 @@ module OpenSearch
         ParamsRegistry.register(:get_settings, [
           :flat_settings,
           :master_timeout,
+          :cluster_manager_timeout,
           :timeout,
           :include_defaults
         ].freeze)

--- a/opensearch-api/lib/opensearch/api/actions/cluster/health.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/health.rb
@@ -34,8 +34,7 @@ module OpenSearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
         # @option arguments [String] :level Specify the level of detail for returned information (options: cluster, indices, shards)
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [String] :wait_for_active_shards Wait until the specified number of shards is active

--- a/opensearch-api/lib/opensearch/api/actions/cluster/health.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/health.rb
@@ -33,8 +33,10 @@ module OpenSearch
         # @option arguments [List] :index Limit the information returned to a specific index
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
         # @option arguments [String] :level Specify the level of detail for returned information (options: cluster, indices, shards)
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [String] :wait_for_active_shards Wait until the specified number of shards is active
         # @option arguments [String] :wait_for_nodes Wait until the specified number of nodes is available
@@ -72,6 +74,7 @@ module OpenSearch
           :level,
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :timeout,
           :wait_for_active_shards,
           :wait_for_nodes,

--- a/opensearch-api/lib/opensearch/api/actions/cluster/pending_tasks.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/pending_tasks.rb
@@ -31,8 +31,10 @@ module OpenSearch
         # Returns a list of any cluster-level changes (e.g. create index, update mapping,
         # allocate or fail shard) which have not yet been executed.
         #
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -54,7 +56,8 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:pending_tasks, [
           :local,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/cluster/pending_tasks.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/pending_tasks.rb
@@ -32,8 +32,7 @@ module OpenSearch
         # allocate or fail shard) which have not yet been executed.
         #
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/cluster/put_component_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/put_component_template.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [String] :name The name of the template
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The template definition (*Required*)
         #
@@ -62,7 +64,8 @@ module OpenSearch
         ParamsRegistry.register(:put_component_template, [
           :create,
           :timeout,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/cluster/put_component_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/put_component_template.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :name The name of the template
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The template definition (*Required*)

--- a/opensearch-api/lib/opensearch/api/actions/cluster/put_settings.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/put_settings.rb
@@ -31,7 +31,9 @@ module OpenSearch
         # Updates the cluster settings.
         #
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart). (*Required*)
@@ -58,6 +60,7 @@ module OpenSearch
         ParamsRegistry.register(:put_settings, [
           :flat_settings,
           :master_timeout,
+          :cluster_manager_timeout,
           :timeout
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/cluster/put_settings.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/put_settings.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Updates the cluster settings.
         #
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/cluster/reroute.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/reroute.rb
@@ -34,8 +34,7 @@ module OpenSearch
         # @option arguments [Boolean] :explain Return an explanation of why the commands can or cannot be executed
         # @option arguments [Boolean] :retry_failed Retries allocation of shards that are blocked due to too many subsequent allocation failures
         # @option arguments [List] :metric Limit the information returned to the specified metrics. Defaults to all but metadata (options: _all, blocks, metadata, nodes, routing_table, cluster_manager_node, version)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/cluster/reroute.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/reroute.rb
@@ -33,8 +33,10 @@ module OpenSearch
         # @option arguments [Boolean] :dry_run Simulate the operation only and return the resulting state
         # @option arguments [Boolean] :explain Return an explanation of why the commands can or cannot be executed
         # @option arguments [Boolean] :retry_failed Retries allocation of shards that are blocked due to too many subsequent allocation failures
-        # @option arguments [List] :metric Limit the information returned to the specified metrics. Defaults to all but metadata (options: _all, blocks, metadata, nodes, routing_table, master_node, version)
+        # @option arguments [List] :metric Limit the information returned to the specified metrics. Defaults to all but metadata (options: _all, blocks, metadata, nodes, routing_table, cluster_manager_node, version)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The definition of `commands` to perform (`move`, `cancel`, `allocate`)
@@ -62,6 +64,7 @@ module OpenSearch
           :retry_failed,
           :metric,
           :master_timeout,
+          :cluster_manager_timeout,
           :timeout
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/cluster/state.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/state.rb
@@ -30,10 +30,12 @@ module OpenSearch
       module Actions
         # Returns a comprehensive information about the state of the cluster.
         #
-        # @option arguments [List] :metric Limit the information returned to the specified metrics (options: _all, blocks, metadata, nodes, routing_table, routing_nodes, master_node, version)
+        # @option arguments [List] :metric Limit the information returned to the specified metrics (options: _all, blocks, metadata, nodes, routing_table, routing_nodes, cluster_manager_node, version)
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Number] :wait_for_metadata_version Wait for the metadata version to be equal or greater than the specified metadata version
         # @option arguments [Time] :wait_for_timeout The maximum time to wait for wait_for_metadata_version before timing out
@@ -72,6 +74,7 @@ module OpenSearch
         ParamsRegistry.register(:state, [
           :local,
           :master_timeout,
+          :cluster_manager_timeout,
           :flat_settings,
           :wait_for_metadata_version,
           :wait_for_timeout,

--- a/opensearch-api/lib/opensearch/api/actions/cluster/state.rb
+++ b/opensearch-api/lib/opensearch/api/actions/cluster/state.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [List] :metric Limit the information returned to the specified metrics (options: _all, blocks, metadata, nodes, routing_table, routing_nodes, cluster_manager_node, version)
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Number] :wait_for_metadata_version Wait for the metadata version to be equal or greater than the specified metadata version

--- a/opensearch-api/lib/opensearch/api/actions/dangling_indices/delete_dangling_index.rb
+++ b/opensearch-api/lib/opensearch/api/actions/dangling_indices/delete_dangling_index.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :index_uuid The UUID of the dangling index
         # @option arguments [Boolean] :accept_data_loss Must be set to true in order to delete the dangling index
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/dangling_indices/delete_dangling_index.rb
+++ b/opensearch-api/lib/opensearch/api/actions/dangling_indices/delete_dangling_index.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [String] :index_uuid The UUID of the dangling index
         # @option arguments [Boolean] :accept_data_loss Must be set to true in order to delete the dangling index
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -60,7 +62,8 @@ module OpenSearch
         ParamsRegistry.register(:delete_dangling_index, [
           :accept_data_loss,
           :timeout,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/dangling_indices/import_dangling_index.rb
+++ b/opensearch-api/lib/opensearch/api/actions/dangling_indices/import_dangling_index.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [String] :index_uuid The UUID of the dangling index
         # @option arguments [Boolean] :accept_data_loss Must be set to true in order to import the dangling index
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         def import_dangling_index(arguments = {})
@@ -59,7 +61,7 @@ module OpenSearch
         ParamsRegistry.register(:import_dangling_index, [
           :accept_data_loss,
           :timeout,
-          :master_timeout
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/dangling_indices/import_dangling_index.rb
+++ b/opensearch-api/lib/opensearch/api/actions/dangling_indices/import_dangling_index.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :index_uuid The UUID of the dangling index
         # @option arguments [Boolean] :accept_data_loss Must be set to true in order to import the dangling index
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/delete_script.rb
+++ b/opensearch-api/lib/opensearch/api/actions/delete_script.rb
@@ -31,8 +31,7 @@ module OpenSearch
       #
       # @option arguments [String] :id Script ID
       # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-      # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
       # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
       # @option arguments [Hash] :headers Custom HTTP headers
       #

--- a/opensearch-api/lib/opensearch/api/actions/delete_script.rb
+++ b/opensearch-api/lib/opensearch/api/actions/delete_script.rb
@@ -31,7 +31,9 @@ module OpenSearch
       #
       # @option arguments [String] :id Script ID
       # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
       # @option arguments [Time] :master_timeout Specify timeout for connection to master
+      # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
       # @option arguments [Hash] :headers Custom HTTP headers
       #
       #
@@ -57,7 +59,8 @@ module OpenSearch
       # @since 6.2.0
       ParamsRegistry.register(:delete_script, [
         :timeout,
-        :master_timeout
+        :master_timeout,
+        :cluster_manager_timeout
       ].freeze)
     end
   end

--- a/opensearch-api/lib/opensearch/api/actions/features/get_features.rb
+++ b/opensearch-api/lib/opensearch/api/actions/features/get_features.rb
@@ -30,7 +30,9 @@ module OpenSearch
       module Actions
         # Gets a list of features which can be included in snapshots using the feature_states field when creating a snapshot
         #
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -51,7 +53,8 @@ module OpenSearch
         #
         # @since 6.2.0
         ParamsRegistry.register(:get_features, [
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/features/get_features.rb
+++ b/opensearch-api/lib/opensearch/api/actions/features/get_features.rb
@@ -30,8 +30,7 @@ module OpenSearch
       module Actions
         # Gets a list of features which can be included in snapshots using the feature_states field when creating a snapshot
         #
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/get_script.rb
+++ b/opensearch-api/lib/opensearch/api/actions/get_script.rb
@@ -30,7 +30,9 @@ module OpenSearch
       # Returns a script.
       #
       # @option arguments [String] :id Script ID
+      # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
       # @option arguments [Time] :master_timeout Specify timeout for connection to master
+      # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
       # @option arguments [Hash] :headers Custom HTTP headers
       #
       #
@@ -55,7 +57,8 @@ module OpenSearch
       #
       # @since 6.2.0
       ParamsRegistry.register(:get_script, [
-        :master_timeout
+        :master_timeout,
+        :cluster_manager_timeout
       ].freeze)
     end
   end

--- a/opensearch-api/lib/opensearch/api/actions/get_script.rb
+++ b/opensearch-api/lib/opensearch/api/actions/get_script.rb
@@ -30,8 +30,7 @@ module OpenSearch
       # Returns a script.
       #
       # @option arguments [String] :id Script ID
-      # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-      # @option arguments [Time] :master_timeout Specify timeout for connection to master
+      # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
       # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
       # @option arguments [Hash] :headers Custom HTTP headers
       #

--- a/opensearch-api/lib/opensearch/api/actions/indices/add_block.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/add_block.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [List] :index A comma separated list of indices to add a block to
         # @option arguments [String] :block The block to add (one of read, write, read_only or metadata)
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
@@ -66,6 +68,7 @@ module OpenSearch
         ParamsRegistry.register(:add_block, [
           :timeout,
           :master_timeout,
+          :cluster_manager_timeout,
           :ignore_unavailable,
           :allow_no_indices,
           :expand_wildcards

--- a/opensearch-api/lib/opensearch/api/actions/indices/add_block.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/add_block.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [List] :index A comma separated list of indices to add a block to
         # @option arguments [String] :block The block to add (one of read, write, read_only or metadata)
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)

--- a/opensearch-api/lib/opensearch/api/actions/indices/clone.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/clone.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :index The name of the source index to clone
         # @option arguments [String] :target The name of the target index to clone into
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the cloned index before the operation returns.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/indices/clone.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/clone.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [String] :index The name of the source index to clone
         # @option arguments [String] :target The name of the target index to clone into
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the cloned index before the operation returns.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The configuration for the target index (`settings` and `aliases`)
@@ -65,6 +67,7 @@ module OpenSearch
         ParamsRegistry.register(:clone, [
           :timeout,
           :master_timeout,
+          :cluster_manager_timeout,
           :wait_for_active_shards
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/indices/close.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/close.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [List] :index A comma separated list of indices to close
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)

--- a/opensearch-api/lib/opensearch/api/actions/indices/close.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/close.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [List] :index A comma separated list of indices to close
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
@@ -63,6 +65,7 @@ module OpenSearch
         ParamsRegistry.register(:close, [
           :timeout,
           :master_timeout,
+          :cluster_manager_timeout,
           :ignore_unavailable,
           :allow_no_indices,
           :expand_wildcards,

--- a/opensearch-api/lib/opensearch/api/actions/indices/create.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/create.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :index The name of the index
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for before the operation returns.
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The configuration for the index (`settings` and `mappings`)

--- a/opensearch-api/lib/opensearch/api/actions/indices/create.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/create.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [String] :index The name of the index
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for before the operation returns.
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The configuration for the index (`settings` and `mappings`)
         #
@@ -61,7 +63,8 @@ module OpenSearch
         ParamsRegistry.register(:create, [
           :wait_for_active_shards,
           :timeout,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/delete.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/delete.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [List] :index A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Ignore unavailable indexes (default: false)
         # @option arguments [Boolean] :allow_no_indices Ignore if a wildcard expression resolves to no concrete indices (default: false)

--- a/opensearch-api/lib/opensearch/api/actions/indices/delete.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/delete.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [List] :index A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Ignore unavailable indexes (default: false)
         # @option arguments [Boolean] :allow_no_indices Ignore if a wildcard expression resolves to no concrete indices (default: false)
         # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open) (options: open, closed, hidden, none, all)
@@ -66,6 +68,7 @@ module OpenSearch
         ParamsRegistry.register(:delete, [
           :timeout,
           :master_timeout,
+          :cluster_manager_timeout,
           :ignore_unavailable,
           :allow_no_indices,
           :expand_wildcards

--- a/opensearch-api/lib/opensearch/api/actions/indices/delete_alias.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/delete_alias.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [List] :index A comma-separated list of index names (supports wildcards); use `_all` for all indices
         # @option arguments [List] :name A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.
         # @option arguments [Time] :timeout Explicit timestamp for the document
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/indices/delete_alias.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/delete_alias.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [List] :index A comma-separated list of index names (supports wildcards); use `_all` for all indices
         # @option arguments [List] :name A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.
         # @option arguments [Time] :timeout Explicit timestamp for the document
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -64,7 +66,8 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:delete_alias, [
           :timeout,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/delete_index_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/delete_index_template.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/indices/delete_index_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/delete_index_template.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -58,7 +60,8 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:delete_index_template, [
           :timeout,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/delete_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/delete_template.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -62,7 +64,8 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:delete_template, [
           :timeout,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/delete_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/delete_template.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/indices/exists.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/exists.rb
@@ -31,7 +31,7 @@ module OpenSearch
         # Returns information about whether a particular index exists.
         #
         # @option arguments [List] :index A comma-separated list of index names
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Boolean] :ignore_unavailable Ignore unavailable indexes (default: false)
         # @option arguments [Boolean] :allow_no_indices Ignore if a wildcard expression resolves to no concrete indices (default: false)
         # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open) (options: open, closed, hidden, none, all)

--- a/opensearch-api/lib/opensearch/api/actions/indices/exists_alias.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/exists_alias.rb
@@ -35,7 +35,7 @@ module OpenSearch
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #

--- a/opensearch-api/lib/opensearch/api/actions/indices/exists_index_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/exists_index_template.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/indices/exists_index_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/exists_index_template.rb
@@ -32,8 +32,10 @@ module OpenSearch
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -62,6 +64,7 @@ module OpenSearch
         ParamsRegistry.register(:exists_index_template, [
           :flat_settings,
           :master_timeout,
+          :cluster_manager_timeout,
           :local
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/indices/exists_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/exists_template.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [List] :name The comma separated names of the index templates
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/indices/exists_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/exists_template.rb
@@ -32,8 +32,10 @@ module OpenSearch
         #
         # @option arguments [List] :name The comma separated names of the index templates
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -65,6 +67,7 @@ module OpenSearch
         ParamsRegistry.register(:exists_template, [
           :flat_settings,
           :master_timeout,
+          :cluster_manager_timeout,
           :local
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/indices/get.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get.rb
@@ -31,13 +31,15 @@ module OpenSearch
         # Returns information about one or more indices.
         #
         # @option arguments [List] :index A comma-separated list of index names
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Boolean] :ignore_unavailable Ignore unavailable indexes (default: false)
         # @option arguments [Boolean] :allow_no_indices Ignore if a wildcard expression resolves to no concrete indices (default: false)
         # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open) (options: open, closed, hidden, none, all)
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Boolean] :include_defaults Whether to return all default setting for each of the indices.
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -68,7 +70,8 @@ module OpenSearch
           :expand_wildcards,
           :flat_settings,
           :include_defaults,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/get.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get.rb
@@ -37,8 +37,7 @@ module OpenSearch
         # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open) (options: open, closed, hidden, none, all)
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Boolean] :include_defaults Whether to return all default setting for each of the indices.
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/indices/get_alias.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get_alias.rb
@@ -35,7 +35,7 @@ module OpenSearch
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #

--- a/opensearch-api/lib/opensearch/api/actions/indices/get_field_mapping.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get_field_mapping.rb
@@ -36,7 +36,7 @@ module OpenSearch
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # *Deprecation notice*:

--- a/opensearch-api/lib/opensearch/api/actions/indices/get_index_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get_index_template.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [List] :name The comma separated names of the index templates
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/indices/get_index_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get_index_template.rb
@@ -32,8 +32,10 @@ module OpenSearch
         #
         # @option arguments [List] :name The comma separated names of the index templates
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -62,6 +64,7 @@ module OpenSearch
         ParamsRegistry.register(:get_index_template, [
           :flat_settings,
           :master_timeout,
+          :cluster_manager_timeout,
           :local
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/indices/get_mapping.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get_mapping.rb
@@ -34,8 +34,7 @@ module OpenSearch
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false) *Deprecated*
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/indices/get_mapping.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get_mapping.rb
@@ -34,8 +34,10 @@ module OpenSearch
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false) *Deprecated*
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false) *Deprecated*
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # *Deprecation notice*:
@@ -71,6 +73,7 @@ module OpenSearch
           :allow_no_indices,
           :expand_wildcards,
           :master_timeout,
+          :cluster_manager_timeout,
           :local
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/indices/get_settings.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get_settings.rb
@@ -32,12 +32,14 @@ module OpenSearch
         #
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
         # @option arguments [List] :name The name of the settings that should be included
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Boolean] :include_defaults Whether to return all default setting for each of the indices.
         # @option arguments [Hash] :headers Custom HTTP headers
         #
@@ -72,6 +74,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:get_settings, [
           :master_timeout,
+          :cluster_manager_timeout,
           :ignore_unavailable,
           :allow_no_indices,
           :expand_wildcards,

--- a/opensearch-api/lib/opensearch/api/actions/indices/get_settings.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get_settings.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
         # @option arguments [List] :name The name of the settings that should be included
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)

--- a/opensearch-api/lib/opensearch/api/actions/indices/get_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get_template.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [List] :name The comma separated names of the index templates
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/indices/get_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/get_template.rb
@@ -32,8 +32,10 @@ module OpenSearch
         #
         # @option arguments [List] :name The comma separated names of the index templates
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -62,6 +64,7 @@ module OpenSearch
         ParamsRegistry.register(:get_template, [
           :flat_settings,
           :master_timeout,
+          :cluster_manager_timeout,
           :local
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/indices/open.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/open.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [List] :index A comma separated list of indices to open
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)

--- a/opensearch-api/lib/opensearch/api/actions/indices/open.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/open.rb
@@ -32,7 +32,8 @@ module OpenSearch
         #
         # @option arguments [List] :index A comma separated list of indices to open
         # @option arguments [Time] :timeout Explicit operation timeout
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
@@ -63,6 +64,7 @@ module OpenSearch
         ParamsRegistry.register(:open, [
           :timeout,
           :master_timeout,
+          :cluster_manager_timeout,
           :ignore_unavailable,
           :allow_no_indices,
           :expand_wildcards,

--- a/opensearch-api/lib/opensearch/api/actions/indices/put_alias.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/put_alias.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [List] :index A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.
         # @option arguments [String] :name The name of the alias to be created or updated
         # @option arguments [Time] :timeout Explicit timestamp for the document
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The settings for the alias, such as `routing` or `filter`

--- a/opensearch-api/lib/opensearch/api/actions/indices/put_alias.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/put_alias.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [List] :index A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.
         # @option arguments [String] :name The name of the alias to be created or updated
         # @option arguments [Time] :timeout Explicit timestamp for the document
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The settings for the alias, such as `routing` or `filter`
         #
@@ -65,7 +67,8 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:put_alias, [
           :timeout,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/put_index_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/put_index_template.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :name The name of the template
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one
         # @option arguments [String] :cause User defined reason for creating/updating the index template
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The template definition (*Required*)

--- a/opensearch-api/lib/opensearch/api/actions/indices/put_index_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/put_index_template.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [String] :name The name of the template
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one
         # @option arguments [String] :cause User defined reason for creating/updating the index template
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The template definition (*Required*)
         #
@@ -62,7 +64,8 @@ module OpenSearch
         ParamsRegistry.register(:put_index_template, [
           :create,
           :cause,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/put_mapping.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/put_mapping.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [List] :index A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)

--- a/opensearch-api/lib/opensearch/api/actions/indices/put_mapping.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/put_mapping.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [List] :index A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
@@ -69,6 +71,7 @@ module OpenSearch
         ParamsRegistry.register(:put_mapping, [
           :timeout,
           :master_timeout,
+          :cluster_manager_timeout,
           :ignore_unavailable,
           :allow_no_indices,
           :expand_wildcards,

--- a/opensearch-api/lib/opensearch/api/actions/indices/put_settings.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/put_settings.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Updates the index settings.
         #
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :preserve_existing Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`

--- a/opensearch-api/lib/opensearch/api/actions/indices/put_settings.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/put_settings.rb
@@ -31,7 +31,9 @@ module OpenSearch
         # Updates the index settings.
         #
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :preserve_existing Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
@@ -68,6 +70,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:put_settings, [
           :master_timeout,
+          :cluster_manager_timeout,
           :timeout,
           :preserve_existing,
           :ignore_unavailable,

--- a/opensearch-api/lib/opensearch/api/actions/indices/put_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/put_template.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [String] :name The name of the template
         # @option arguments [Number] :order The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The template definition (*Required*)
         #
@@ -62,7 +64,8 @@ module OpenSearch
         ParamsRegistry.register(:put_template, [
           :order,
           :create,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/put_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/put_template.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :name The name of the template
         # @option arguments [Number] :order The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The template definition (*Required*)

--- a/opensearch-api/lib/opensearch/api/actions/indices/rollover.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/rollover.rb
@@ -35,8 +35,7 @@ module OpenSearch
         # @option arguments [String] :new_index The name of the rollover index
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :dry_run If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the newly created rollover index before the operation returns.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/indices/rollover.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/rollover.rb
@@ -35,7 +35,9 @@ module OpenSearch
         # @option arguments [String] :new_index The name of the rollover index
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :dry_run If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the newly created rollover index before the operation returns.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The conditions that needs to be met for executing rollover
@@ -71,6 +73,7 @@ module OpenSearch
           :timeout,
           :dry_run,
           :master_timeout,
+          :cluster_manager_timeout,
           :wait_for_active_shards
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/indices/shrink.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/shrink.rb
@@ -34,8 +34,7 @@ module OpenSearch
         # @option arguments [String] :target The name of the target index to shrink into
         # @option arguments [Boolean] :copy_settings whether or not to copy settings from the source index (defaults to false)
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the shrunken index before the operation returns.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/indices/shrink.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/shrink.rb
@@ -34,7 +34,9 @@ module OpenSearch
         # @option arguments [String] :target The name of the target index to shrink into
         # @option arguments [Boolean] :copy_settings whether or not to copy settings from the source index (defaults to false)
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the shrunken index before the operation returns.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The configuration for the target index (`settings` and `aliases`)
@@ -67,6 +69,7 @@ module OpenSearch
           :copy_settings,
           :timeout,
           :master_timeout,
+          :cluster_manager_timeout,
           :wait_for_active_shards
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/indices/simulate_index_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/simulate_index_template.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :name The name of the index (it must be a concrete index name)
         # @option arguments [Boolean] :create Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one
         # @option arguments [String] :cause User defined reason for dry-run creating the new template for simulation purposes
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body New index template definition, which will be included in the simulation, as if it already exists in the system

--- a/opensearch-api/lib/opensearch/api/actions/indices/simulate_index_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/simulate_index_template.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [String] :name The name of the index (it must be a concrete index name)
         # @option arguments [Boolean] :create Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one
         # @option arguments [String] :cause User defined reason for dry-run creating the new template for simulation purposes
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body New index template definition, which will be included in the simulation, as if it already exists in the system
         #
@@ -61,7 +63,8 @@ module OpenSearch
         ParamsRegistry.register(:simulate_index_template, [
           :create,
           :cause,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/simulate_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/simulate_template.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [String] :name The name of the index template
         # @option arguments [Boolean] :create Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one
         # @option arguments [String] :cause User defined reason for dry-run creating the new template for simulation purposes
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body New index template definition to be simulated, if no index template name is specified
         #
@@ -63,7 +65,8 @@ module OpenSearch
         ParamsRegistry.register(:simulate_template, [
           :create,
           :cause,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/simulate_template.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/simulate_template.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :name The name of the index template
         # @option arguments [Boolean] :create Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one
         # @option arguments [String] :cause User defined reason for dry-run creating the new template for simulation purposes
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body New index template definition to be simulated, if no index template name is specified

--- a/opensearch-api/lib/opensearch/api/actions/indices/split.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/split.rb
@@ -34,7 +34,9 @@ module OpenSearch
         # @option arguments [String] :target The name of the target index to split into
         # @option arguments [Boolean] :copy_settings whether or not to copy settings from the source index (defaults to false)
         # @option arguments [Time] :timeout Explicit operation timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the shrunken index before the operation returns.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The configuration for the target index (`settings` and `aliases`)
@@ -67,6 +69,7 @@ module OpenSearch
           :copy_settings,
           :timeout,
           :master_timeout,
+          :cluster_manager_timeout,
           :wait_for_active_shards
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/indices/split.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/split.rb
@@ -34,8 +34,7 @@ module OpenSearch
         # @option arguments [String] :target The name of the target index to split into
         # @option arguments [Boolean] :copy_settings whether or not to copy settings from the source index (defaults to false)
         # @option arguments [Time] :timeout Explicit operation timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the shrunken index before the operation returns.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/indices/update_aliases.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/update_aliases.rb
@@ -31,7 +31,9 @@ module OpenSearch
         # Updates index aliases.
         #
         # @option arguments [Time] :timeout Request timeout
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The definition of `actions` to perform (*Required*)
         #
@@ -56,7 +58,8 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:update_aliases, [
           :timeout,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/indices/update_aliases.rb
+++ b/opensearch-api/lib/opensearch/api/actions/indices/update_aliases.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Updates index aliases.
         #
         # @option arguments [Time] :timeout Request timeout
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
         # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The definition of `actions` to perform (*Required*)

--- a/opensearch-api/lib/opensearch/api/actions/ingest/delete_pipeline.rb
+++ b/opensearch-api/lib/opensearch/api/actions/ingest/delete_pipeline.rb
@@ -31,7 +31,9 @@ module OpenSearch
         # Deletes a pipeline.
         #
         # @option arguments [String] :id Pipeline ID
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
@@ -58,6 +60,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:delete_pipeline, [
           :master_timeout,
+          :cluster_manager_timeout,
           :timeout
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/ingest/delete_pipeline.rb
+++ b/opensearch-api/lib/opensearch/api/actions/ingest/delete_pipeline.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Deletes a pipeline.
         #
         # @option arguments [String] :id Pipeline ID
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/ingest/get_pipeline.rb
+++ b/opensearch-api/lib/opensearch/api/actions/ingest/get_pipeline.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [String] :id Comma separated list of pipeline ids. Wildcards supported
         # @option arguments [Boolean] :summary Return pipelines without their definitions (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -60,7 +62,8 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:get_pipeline, [
           :summary,
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/ingest/get_pipeline.rb
+++ b/opensearch-api/lib/opensearch/api/actions/ingest/get_pipeline.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :id Comma separated list of pipeline ids. Wildcards supported
         # @option arguments [Boolean] :summary Return pipelines without their definitions (default: false)
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/ingest/put_pipeline.rb
+++ b/opensearch-api/lib/opensearch/api/actions/ingest/put_pipeline.rb
@@ -31,7 +31,9 @@ module OpenSearch
         # Creates or updates a pipeline.
         #
         # @option arguments [String] :id Pipeline ID
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The ingest definition (*Required*)

--- a/opensearch-api/lib/opensearch/api/actions/ingest/put_pipeline.rb
+++ b/opensearch-api/lib/opensearch/api/actions/ingest/put_pipeline.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Creates or updates a pipeline.
         #
         # @option arguments [String] :id Pipeline ID
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/put_script.rb
+++ b/opensearch-api/lib/opensearch/api/actions/put_script.rb
@@ -32,8 +32,7 @@ module OpenSearch
       # @option arguments [String] :id Script ID
       # @option arguments [String] :context Script context
       # @option arguments [Time] :timeout Explicit operation timeout
-      # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-      # @option arguments [Time] :master_timeout Specify timeout for connection to master
+      # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Specify timeout for connection to master
       # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The document (*Required*)

--- a/opensearch-api/lib/opensearch/api/actions/put_script.rb
+++ b/opensearch-api/lib/opensearch/api/actions/put_script.rb
@@ -32,7 +32,9 @@ module OpenSearch
       # @option arguments [String] :id Script ID
       # @option arguments [String] :context Script context
       # @option arguments [Time] :timeout Explicit operation timeout
+      # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
       # @option arguments [Time] :master_timeout Specify timeout for connection to master
+      # @option arguments [Time] :cluster_manager_timeout Specify timeout for connection to cluster_manager
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The document (*Required*)
       #
@@ -67,6 +69,7 @@ module OpenSearch
       ParamsRegistry.register(:put_script, [
         :timeout,
         :master_timeout,
+        :cluster_manager_timeout,
         :context
       ].freeze)
     end

--- a/opensearch-api/lib/opensearch/api/actions/search_shards.rb
+++ b/opensearch-api/lib/opensearch/api/actions/search_shards.rb
@@ -32,7 +32,7 @@ module OpenSearch
       # @option arguments [List] :index A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
       # @option arguments [String] :preference Specify the node or shard the operation should be performed on (default: random)
       # @option arguments [String] :routing Specific routing value
-      # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+      # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
       # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
       # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/cleanup_repository.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/cleanup_repository.rb
@@ -31,7 +31,9 @@ module OpenSearch
         # Removes stale data from repository.
         #
         # @option arguments [String] :repository A repository name
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
@@ -58,6 +60,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:cleanup_repository, [
           :master_timeout,
+          :cluster_manager_timeout,
           :timeout
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/cleanup_repository.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/cleanup_repository.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Removes stale data from repository.
         #
         # @option arguments [String] :repository A repository name
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/clone.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/clone.rb
@@ -33,8 +33,7 @@ module OpenSearch
         # @option arguments [String] :repository A repository name
         # @option arguments [String] :snapshot The name of the snapshot to clone from
         # @option arguments [String] :target_snapshot The name of the cloned snapshot to create
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The snapshot clone definition (*Required*)

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/clone.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/clone.rb
@@ -33,7 +33,9 @@ module OpenSearch
         # @option arguments [String] :repository A repository name
         # @option arguments [String] :snapshot The name of the snapshot to clone from
         # @option arguments [String] :target_snapshot The name of the cloned snapshot to create
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The snapshot clone definition (*Required*)
         #
@@ -66,7 +68,8 @@ module OpenSearch
         #
         # @since 6.2.0
         ParamsRegistry.register(:clone, [
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/create.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/create.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :repository A repository name
         # @option arguments [String] :snapshot A snapshot name
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :wait_for_completion Should this request wait until the operation has completed before returning
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/create.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/create.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [String] :repository A repository name
         # @option arguments [String] :snapshot A snapshot name
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :wait_for_completion Should this request wait until the operation has completed before returning
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The snapshot definition
@@ -63,6 +65,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:create, [
           :master_timeout,
+          :cluster_manager_timeout,
           :wait_for_completion
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/create_repository.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/create_repository.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Creates a repository.
         #
         # @option arguments [String] :repository A repository name
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :verify Whether to verify the repository after creation

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/create_repository.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/create_repository.rb
@@ -31,7 +31,9 @@ module OpenSearch
         # Creates a repository.
         #
         # @option arguments [String] :repository A repository name
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :verify Whether to verify the repository after creation
         # @option arguments [Hash] :headers Custom HTTP headers
@@ -61,6 +63,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:create_repository, [
           :master_timeout,
+          :cluster_manager_timeout,
           :timeout,
           :verify
         ].freeze)

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/delete.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/delete.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :repository A repository name
         # @option arguments [String] :snapshot A snapshot name
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/delete.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/delete.rb
@@ -32,7 +32,8 @@ module OpenSearch
         #
         # @option arguments [String] :repository A repository name
         # @option arguments [String] :snapshot A snapshot name
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -64,7 +65,8 @@ module OpenSearch
         #
         # @since 6.2.0
         ParamsRegistry.register(:delete, [
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/delete_repository.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/delete_repository.rb
@@ -31,7 +31,9 @@ module OpenSearch
         # Deletes a repository.
         #
         # @option arguments [List] :repository Name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
@@ -61,7 +63,7 @@ module OpenSearch
         #
         # @since 6.2.0
         ParamsRegistry.register(:delete_repository, [
-          :master_timeout,
+          :cluster_manager_timeout,
           :timeout
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/delete_repository.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/delete_repository.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Deletes a repository.
         #
         # @option arguments [List] :repository Name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/get.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/get.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :repository A repository name
         # @option arguments [List] :snapshot A comma-separated list of snapshot names
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :ignore_unavailable Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown
         # @option arguments [Boolean] :index_details Whether to include details of each index in the snapshot, if those details are available. Defaults to false.

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/get.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/get.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [String] :repository A repository name
         # @option arguments [List] :snapshot A comma-separated list of snapshot names
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :ignore_unavailable Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown
         # @option arguments [Boolean] :index_details Whether to include details of each index in the snapshot, if those details are available. Defaults to false.
         # @option arguments [Boolean] :include_repository Whether to include the repository name in the snapshot info. Defaults to true.
@@ -69,6 +71,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:get, [
           :master_timeout,
+          :cluster_manager_timeout,
           :ignore_unavailable,
           :index_details,
           :include_repository,

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/get_features.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/get_features.rb
@@ -30,8 +30,7 @@ module OpenSearch
       module Actions
         # Returns a list of features which can be snapshotted in this cluster.
         #
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/get_features.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/get_features.rb
@@ -30,7 +30,8 @@ module OpenSearch
       module Actions
         # Returns a list of features which can be snapshotted in this cluster.
         #
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -51,7 +52,8 @@ module OpenSearch
         #
         # @since 6.2.0
         ParamsRegistry.register(:get_features, [
-          :master_timeout
+          :master_timeout,
+          :cluster_manager_timeout
         ].freeze)
       end
     end

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/get_repository.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/get_repository.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Returns information about a repository.
         #
         # @option arguments [List] :repository A comma-separated list of repository names
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/get_repository.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/get_repository.rb
@@ -31,8 +31,9 @@ module OpenSearch
         # Returns information about a repository.
         #
         # @option arguments [List] :repository A comma-separated list of repository names
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from cluster_manager node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         #
@@ -64,6 +65,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:get_repository, [
           :master_timeout,
+          :cluster_manager_timeout,
           :local
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/restore.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/restore.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :repository A repository name
         # @option arguments [String] :snapshot A snapshot name
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :wait_for_completion Should this request wait until the operation has completed before returning
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/restore.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/restore.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [String] :repository A repository name
         # @option arguments [String] :snapshot A snapshot name
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :wait_for_completion Should this request wait until the operation has completed before returning
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body Details of what to restore
@@ -63,6 +65,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:restore, [
           :master_timeout,
+          :cluster_manager_timeout,
           :wait_for_completion
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/status.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/status.rb
@@ -32,7 +32,9 @@ module OpenSearch
         #
         # @option arguments [String] :repository A repository name
         # @option arguments [List] :snapshot A comma-separated list of snapshot names
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :ignore_unavailable Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown
         # @option arguments [Hash] :headers Custom HTTP headers
         #
@@ -69,6 +71,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:status, [
           :master_timeout,
+          :cluster_manager_timeout,
           :ignore_unavailable
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/status.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/status.rb
@@ -32,8 +32,7 @@ module OpenSearch
         #
         # @option arguments [String] :repository A repository name
         # @option arguments [List] :snapshot A comma-separated list of snapshot names
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Boolean] :ignore_unavailable Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/verify_repository.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/verify_repository.rb
@@ -31,8 +31,7 @@ module OpenSearch
         # Verifies a repository.
         #
         # @option arguments [String] :repository A repository name
-        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :master_timeout (DEPRECATED: use cluster_manager_timeout instead) Explicit operation timeout for connection to master node
         # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/opensearch-api/lib/opensearch/api/actions/snapshot/verify_repository.rb
+++ b/opensearch-api/lib/opensearch/api/actions/snapshot/verify_repository.rb
@@ -31,7 +31,9 @@ module OpenSearch
         # Verifies a repository.
         #
         # @option arguments [String] :repository A repository name
+        # <b>DEPRECATED:</b> Please use <tt>cluster_manager_timeout</tt> instead.
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :cluster_manager_timeout Explicit operation timeout for connection to cluster_manager node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
@@ -58,6 +60,7 @@ module OpenSearch
         # @since 6.2.0
         ParamsRegistry.register(:verify_repository, [
           :master_timeout,
+          :cluster_manager_timeout,
           :timeout
         ].freeze)
       end

--- a/opensearch-api/lib/opensearch/api/utils.rb
+++ b/opensearch-api/lib/opensearch/api/utils.rb
@@ -97,13 +97,13 @@ module OpenSearch
       # in a single item.
       #
       #     OpenSearch::API::Utils.__bulkify [
-      #       { :index =>  { :_index => 'myindexA', :_type => 'mytype', :_id => '1', :data => { :title => 'Test' } } },
-      #       { :update => { :_index => 'myindexB', :_type => 'mytype', :_id => '2', :data => { :doc => { :title => 'Update' } } } }
+      #       { :index =>  { :_index => 'myindexA', :_id => '1', :data => { :title => 'Test' } } },
+      #       { :update => { :_index => 'myindexB', :_id => '2', :data => { :doc => { :title => 'Update' } } } }
       #     ]
       #
-      #     # => {"index":{"_index":"myindexA","_type":"mytype","_id":"1"}}
+      #     # => {"index":{"_index":"myindexA","_id":"1"}}
       #     # => {"title":"Test"}
-      #     # => {"update":{"_index":"myindexB","_type":"mytype","_id":"2"}}
+      #     # => {"update":{"_index":"myindexB","_id":"2"}}
       #     # => {"doc":{"title":"Update"}}
       #
       def __bulkify(payload)

--- a/opensearch-api/spec/opensearch/api/actions/cat/cluster_manager_spec.rb
+++ b/opensearch-api/spec/opensearch/api/actions/cat/cluster_manager_spec.rb
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+require 'spec_helper'
+
+describe 'client.cat#cluster_manager' do
+
+  let(:expected_args) do
+    [
+        'GET',
+        '_cat/cluster_manager',
+        {},
+        nil,
+        {}
+    ]
+  end
+
+  it 'performs the request' do
+    expect(client_double.cat.cluster_manager).to eq({})
+  end
+end

--- a/opensearch-api/spec/opensearch/api/actions/cat/master_spec.rb
+++ b/opensearch-api/spec/opensearch/api/actions/cat/master_spec.rb
@@ -26,7 +26,6 @@
 
 require 'spec_helper'
 
-# <b>DEPRECATED:</b> Please use <tt>cluster_manager</tt> instead.
 describe 'client.cat#master' do
 
   let(:expected_args) do

--- a/opensearch-api/spec/opensearch/api/actions/cat/master_spec.rb
+++ b/opensearch-api/spec/opensearch/api/actions/cat/master_spec.rb
@@ -26,6 +26,7 @@
 
 require 'spec_helper'
 
+# <b>DEPRECATED:</b> Please use <tt>cluster_manager</tt> instead.
 describe 'client.cat#master' do
 
   let(:expected_args) do

--- a/opensearch-api/spec/opensearch/api/actions/get_script_spec.rb
+++ b/opensearch-api/spec/opensearch/api/actions/get_script_spec.rb
@@ -49,11 +49,11 @@ describe 'client#get_script' do
   context 'when the `lang` parameter is specificed' do
 
     let(:params) do
-      { master_timeout: '1s' }
+      { cluster_manager_timeout: '1s' }
     end
 
     it 'performs the request' do
-      expect(client_double.get_script(master_timeout: '1s', id: 'foo')).to eq({})
+      expect(client_double.get_script(cluster_manager_timeout: '1s', id: 'foo')).to eq({})
     end
   end
 end

--- a/opensearch-api/spec/opensearch/api/actions/hashie_spec.rb
+++ b/opensearch-api/spec/opensearch/api/actions/hashie_spec.rb
@@ -45,7 +45,6 @@ describe 'Hashie' do
                 "hits": [
                   {
                     "_index": "myindex",
-                    "_type": "mytype",
                     "_id": "1",
                     "_score": 0.51104903,
                     "_source": {
@@ -63,7 +62,6 @@ describe 'Hashie' do
               },
               "facets": {
                 "tags": {
-                  "_type": "terms",
                   "missing": 0,
                   "total": 10,
                   "other": 0,

--- a/opensearch-api/spec/opensearch/api/actions/indices/clone_spec.rb
+++ b/opensearch-api/spec/opensearch/api/actions/indices/clone_spec.rb
@@ -88,7 +88,7 @@ describe 'client.indices#clone' do
     let(:params) do
       {
           timeout: '1s',
-          master_timeout: '10s',
+          cluster_manager_timeout: '10s',
           wait_for_active_shards: 1
       }
     end
@@ -97,7 +97,7 @@ describe 'client.indices#clone' do
       expect(client_double.indices.clone(index: 'my_source_index',
                                          target: 'my_target_index',
                                          timeout: '1s',
-                                         master_timeout: '10s',
+                                         cluster_manager_timeout: '10s',
                                          wait_for_active_shards: 1)).to eq({})
     end
   end

--- a/opensearch-api/spec/opensearch/api/utils_spec.rb
+++ b/opensearch-api/spec/opensearch/api/utils_spec.rb
@@ -109,19 +109,19 @@ describe OpenSearch::API::Utils do
 
       let(:result) do
         utils.__bulkify [
-          { :index =>  { :_index => 'myindexA', :_type => 'mytype', :_id => '1', :data => { :title => 'Test' } } },
-          { :update => { :_index => 'myindexB', :_type => 'mytype', :_id => '2', :data => { :doc => { :title => 'Update' } } } },
-          { :delete => { :_index => 'myindexC', :_type => 'mytypeC', :_id => '3' } }
+          { :index =>  { :_index => 'myindexA', :_id => '1', :data => { :title => 'Test' } } },
+          { :update => { :_index => 'myindexB', :_id => '2', :data => { :doc => { :title => 'Update' } } } },
+          { :delete => { :_index => 'myindexC', :_id => '3' } }
         ]
       end
 
       let(:expected_string) do
         <<-PAYLOAD.gsub(/^\s+/, '')
-                {"index":{"_index":"myindexA","_type":"mytype","_id":"1"}}
+                {"index":{"_index":"myindexA","_id":"1"}}
                 {"title":"Test"}
-                {"update":{"_index":"myindexB","_type":"mytype","_id":"2"}}
+                {"update":{"_index":"myindexB","_id":"2"}}
                 {"doc":{"title":"Update"}}
-                {"delete":{"_index":"myindexC","_type":"mytypeC","_id":"3"}}
+                {"delete":{"_index":"myindexC","_id":"3"}}
         PAYLOAD
       end
 

--- a/opensearch-dsl/opensearch-dsl.gemspec
+++ b/opensearch-dsl/opensearch-dsl.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'cane'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'minitest-reporters', '~> 1'
-  s.add_development_dependency 'mocha', '~> 1'
+  s.add_development_dependency 'mocha'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'shoulda-context'
   s.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'

--- a/opensearch-transport/spec/opensearch/transport/sniffer_spec.rb
+++ b/opensearch-transport/spec/opensearch/transport/sniffer_spec.rb
@@ -93,7 +93,7 @@ describe OpenSearch::Transport::Transport::Sniffer do
                 "ip"   => "127.0.0.1",
                 "version" => "7.0.0",
                 "roles" => [
-                  "master",
+                  "cluster_manager",
                   "data",
                   "ingest"
                 ],
@@ -135,7 +135,7 @@ describe OpenSearch::Transport::Transport::Sniffer do
       end
 
       it 'parses the roles' do
-        expect(sniffer.hosts[0][:roles]).to eq(['master',
+        expect(sniffer.hosts[0][:roles]).to eq(['cluster_manager',
                                                 'data',
                                                 'ingest'])
       end

--- a/profile/benchmarking/measurable.rb
+++ b/profile/benchmarking/measurable.rb
@@ -247,7 +247,7 @@ module OpenSearch
       def dataset_slices(slice_size=10000)
         @dataset_slices ||= begin
           dataset.collect do |d|
-            { index: { _index: INDEX, _type: '_doc', data: d } }
+            { index: { _index: INDEX, data: d } }
           end.each_slice(slice_size)
         end
       end


### PR DESCRIPTION
### Description
 - Renames `master` to `cluster_manager`
 - Adds `cluster_manager_timeout` while deprecating `master_timeout`
 - Adds a new `cat/cluster_manager` API while deprecating `cat/master`

### Issues Resolved
Closes #72 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
