### PR TITLE
Update Maintainers List

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @opensearch-project/clients @robsears
+* @VijayanB @jayeshathila @robsears @vamshin @dblock @VachaShah @nhtruong

--- a/ADMINS.md
+++ b/ADMINS.md
@@ -1,6 +1,4 @@
-## Overview
-
-This document explains who the admins are (see below), what they do in this repo, and how they should be doing it. If you're interested in becoming a maintainer, see [MAINTAINERS](MAINTAINERS.md). If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+# OpenSearch Ruby Client Admins
 
 ## Current Admins
 
@@ -13,20 +11,5 @@ This document explains who the admins are (see below), what they do in this repo
 | Yuvraj Jaiswal           | [yuvi17](https://github.com/yuvi17)                 | Amazon      |
 
 
-## Admin Responsibilities
-
-As an admin you own stewartship of the repository and its settings. Admins have [admin-level permissions on a repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization). Use those privileges to serve the community and protect the repository as follows.
-
-### Prioritize Security
-
-Security is your number one priority. Manage security keys and safeguard access to the repository.
-
-Note that this repository is monitored and supported 24/7 by Amazon Security, see [Reporting a Vulnerability](SECURITY.md) for details.
-
-### Enforce Code of Conduct
-
-Act on [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) violations by revoking access, and blocking malicious actors.
-
-### Adopt Organizational Best Practices
-
-Adopt organizational best practices, work in the open, and collaborate with other admins by opening issues before making process changes. Prefer consistency, and avoid diverging from practices in the opensearch-project organization.
+[This document](https://github.com/opensearch-project/.github/blob/main/ADMINS.md)
+explains what an admin's responsibilities are.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,78 +1,23 @@
-- [Overview](#overview)
-- [Current Maintainers](#current-maintainers)
-- [Maintainer Responsibilities](#maintainer-responsibilities)
-  - [Uphold Code of Conduct](#uphold-code-of-conduct)
-  - [Prioritize Security](#prioritize-security)
-  - [Review Pull Requests](#review-pull-requests)
-  - [Triage Open Issues](#triage-open-issues)
-  - [Backports](#backports)
-  - [Be Responsive](#be-responsive)
-  - [Maintain Overall Health of the Repo](#maintain-overall-health-of-the-repo)
-  - [Use Semver](#use-semver)
-  - [Release Frequently](#release-frequently)
-  - [Promote Other Maintainers](#promote-other-maintainers)
-  
-## Overview
-
-This document explains who the maintainers are (see below), what they do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+# OpenSearch Ruby Client Maintainers
 
 ## Current Maintainers
 
-| Maintainer               | GitHub ID                                       | Affiliation |
-| ------------------------ | ---------------------------------------         | ----------- |
-| Vijayan Balasubramanian  | [VijayanB](https://github.com/VijayanB)         |   Amazon    |
-| Jayesh Hathila           | [jayeshathila](https://github.com/jayeshathila) |   Amazon    |
-| Rob Sears                | [robsears](https://github.com/robsears)         |   Bonsai    |
-| Vamshi Vijay Nakkirtha   | [vamshin](https://github.com/vamshin)           |   Amazon    |
-| Yuvraj Jaiswal           | [yuvi17](https://github.com/yuvi17)             |   Amazon    |
+| Maintainer              | GitHub ID                                       | Affiliation |
+|-------------------------|-------------------------------------------------|-------------|
+| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)         | Amazon      |
+| Jayesh Hathila          | [jayeshathila](https://github.com/jayeshathila) | Amazon      |
+| Rob Sears               | [robsears](https://github.com/robsears)         | Bonsai      |
+| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)           | Amazon      |
+| Daniel Doubrovkine      | [dblock](https://github.com/dblock)             | Amazon      |
+| Vacha Shah              | [VachaShah](https://github.com/VachaShah)       | Amazon      |
+| Theo Truong             | [nhtruong](https://github.com/nhtruong)         | Amazon      |
 
-## Maintainer Responsibilities
+## Emeritus
 
-Maintainers are active and visible members of the community, and have [maintain-level permissions on a repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization). Use those privileges to serve the community and evolve code as follows.
+| Maintainer              | GitHub ID                                       | Affiliation |
+|-------------------------|-------------------------------------------------|-------------|
+| Yuvraj Jaiswal          | [yuvi17](https://github.com/yuvi17)             | Amazon      |
 
-### Uphold Code of Conduct
-
-Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers and admins.
-
-### Prioritize Security
-
-Security is your number one priority. Maintainer's Github keys must be password protected securely and any reported security vulnerabilities are addressed before features or bugs.
-
-Note that this repository is monitored and supported 24/7 by Amazon Security, see [Reporting a Vulnerability](SECURITY.md) for details.
-
-### Review Pull Requests
-
-Review pull requests regularly, comment, suggest, reject, merge and close. Accept only high quality pull-requests. Provide code reviews and guidance on incomming pull requests. Don't let PRs be stale and do your best to be helpful to contributors.
-
-### Triage Open Issues
-
-Manage labels, review issues regularly, and triage by labelling them. 
-
-All repositories in this organization have a standard set of labels, including `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `blocker`, `invalid`, `question`, `wontfix`, and `untriaged`, along with release labels, such as `v1.0.0`, `v1.1.0`, `v2.0.0`, `patch`, and `backport`.
-
-Use labels to target an issue or a PR for a given release, add `help wanted` to good issues for new community members, and `blocker` for issues that scare you or need immediate attention. Request for more information from a submitter if an issue is not clear. Create new labels as needed by the project.
-
-### Backports
-
-The Github workflow in [backport.yml](.github/workflows/backport.yml) creates backport PRs automatically when the original PR with an appropriate label `backport <backport-branch-name>` is merged to main. To backport a PR to `1.x`, add a label `backport 1.x` to the PR, once this PR is merged to main, the workflow will create a backport PR to the `1.x` branch.
-
-### Be Responsive
-
-Respond to enhancement requests, and forum posts. Allocate time to reviewing and commenting on issues and conversations as they come in. 
-
-### Maintain Overall Health of the Repo
-
-Keep the `main` branch at production quality at all times. Backport features as needed. Cut release branches and tags to enable future patches. 
-
-### Use Semver
-
-Use and enforce [semantic versioning](https://semver.org/) and do not let breaking changes be made outside of major releases.
-
-### Release Frequently
-
-Make frequent project releases to the community.
-
-### Promote Other Maintainers
-
-Assist, add, and remove [MAINTAINERS](MAINTAINERS.md). Exercise good judgement, and propose high quality contributors to become co-maintainers.
-
+[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md)
+explains what maintainers do in this repo, and how they should be doing it.
+If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
- Added @dblock, @VachaShah, and @nhtruong as maintainers.
- Updated CODEOWNERS to reflect the current maintainers.
- Updated MAINTAINERS.md to refer to opensearch-project's MAINTAINERS.md for consistency and avoid duplication.
- Updated ADMINS.md to refer to opensearch-project's ADMINS.md for consistency and avoid duplication.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
