### PR TITLE
Github Pages Workflow

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,0 +1,34 @@
+name: Publish Docs to Github Pages
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    name: Update gh-pages with docs
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+      - name: Install Ruby gems
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev
+          rake bundle:clean
+          rake bundle:install
+      - name: Generate Docs
+        run: rake gh_pages
+      - name: Commit Docs Change
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          add: 'docs/* -f'
+      - name: Deploy Docs to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          keep_files: true
+          enable_jekyll: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ _yardoc
 coverage
 **/test/reports/
 **/test/html_reports/
-doc/
+docs/
 rdoc/
 tmp
 Gemfile.lock

--- a/Rakefile
+++ b/Rakefile
@@ -106,6 +106,13 @@ namespace :bundle do
   end
 end
 
+
+require_relative 'scripts/github_pages_generator'
+desc "Generate documentation for all subprojects to be published to gh-pages"
+task :gh_pages do
+  GithubPagesGenerator.new(CURRENT_PATH).generate('docs')
+end
+
 desc "Generate documentation for all subprojects"
 task :doc do
   SUBPROJECTS.each do |project|

--- a/opensearch/opensearch.gemspec
+++ b/opensearch/opensearch.gemspec
@@ -61,8 +61,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4'
 
-  s.add_dependency 'opensearch-transport', '~> 2.0.0'
-  s.add_dependency 'opensearch-api',       '2.0.2'
+  s.add_dependency 'opensearch-transport', '~> 2'
+  s.add_dependency 'opensearch-api',       '~> 2'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'byebug' unless defined?(JRUBY_VERSION) || defined?(Rubinius)

--- a/scripts/github_pages_generator.rb
+++ b/scripts/github_pages_generator.rb
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+require 'pathname'
+require 'bundler/gem_helper'
+require_relative '../opensearch/lib/opensearch/version'
+require_relative '../opensearch-api/lib/opensearch/api/version'
+require_relative '../opensearch-dsl/lib/opensearch/dsl/version'
+require_relative '../opensearch-transport/lib/opensearch/transport/version'
+
+# Generate Docs for Github Pages
+class GithubPagesGenerator
+  INDEX_FILE = 'index.md'
+  GEMS = [
+    { folder: 'opensearch', version: OpenSearch::VERSION, name: 'OpenSearch Ruby' },
+    { folder: 'opensearch-dsl', version: OpenSearch::DSL::VERSION, name: 'OpenSearch DSL' },
+    { folder: 'opensearch-api', version: OpenSearch::API::VERSION, name: 'OpenSearch API' },
+    { folder: 'opensearch-transport', version: OpenSearch::Transport::VERSION, name: 'OpenSearch Transport' },
+  ].freeze
+
+  attr_reader :root, :index_file
+
+  def initialize(root)
+    @root = Pathname(root)
+  end
+
+  def generate(output_folder)
+    @index_file =  root.join(output_folder, INDEX_FILE)
+    index_file.delete if index_file.exist?
+    generate_docs(output_folder)
+    generate_index(output_folder)
+  end
+
+  private
+
+  def generate_docs(output_folder)
+    GEMS.each do |gem|
+      minor_version = gem[:version].split('.')[0..1].join('.')
+      output_dir = root.join(output_folder, gem[:folder], minor_version)
+      yard_cmd = "yard doc --embed-mixins --markup=rdoc -o #{output_dir}"
+      Kernel.system "cd #{root.join(gem[:folder])} && #{yard_cmd}"
+    end
+  end
+
+  def generate_index(output_folder)
+    docs = GEMS.map do |gem|
+      gem_path = root.join(output_folder, gem[:folder])
+      versions = gem_path.children.sort.reverse.map do |version_path|
+        version = version_path.basename
+        "- [#{version}.x](#{gem[:folder]}/#{version})"
+      end
+
+      ['', "### #{gem[:name]}:"] + versions
+    end
+
+    File.open(index_file, 'w') do |f|
+      f.puts '## OpenSearch Ruby Documentation'
+      f.puts 'Below is the list of all OpenSearch gems and their documentation:'
+      f.puts docs
+    end
+  end
+end


### PR DESCRIPTION
- Added `gh_pages` rake task that generates Yard docs for the current versions of all gems. The task also generate an `index.md` to be consumed by Github Pages.
- Added a workflow to run the above rake task, commit the docs to `main` branch (To preserve the different versions of the docs), and push the docs to `gh_pages` branch to be consumed by Github Pages.
- `opensearch-ruby` gem's dependency on API and Transport gems now allow `2.x.x` versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
