### PR TITLE
Fixed Mocha Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
-
+- Mocha Dependency issue in `opensearch-dsl` gem ([#108](https://github.com/opensearch-project/opensearch-ruby/pull/108))
+ 
 ### Security
 
 

--- a/opensearch-dsl/opensearch-dsl.gemspec
+++ b/opensearch-dsl/opensearch-dsl.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'cane'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'minitest-reporters', '~> 1'
-  s.add_development_dependency 'mocha'
+  s.add_development_dependency 'mocha', '~> 1'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'shoulda-context'
   s.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'


### PR DESCRIPTION
Opensearch-DSL gem was using Mocha 1.x.x for its unit tests. Mocha has just released 2.0.0 which breaks some of the tests. This will lock mocha to 1.x.x for Opensearch-DSL

Signed-off-by: Theo Truong <theotr@amazon.com>