### PR TITLE
Aws Sigv4 Wrapper Gem for OpenSearch::Client

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -47,6 +47,8 @@ jobs:
         run: cd opensearch-api && bundle exec rake test:spec
       - name: opensearch-dsl
         run: cd opensearch-dsl && bundle exec rake test:all
+      - name: opensearch-aws-sigv4
+        run: cd opensearch-aws-sigv4 && bundle exec rake test:all
 
 
   test-opensearch-security:
@@ -81,5 +83,5 @@ jobs:
           ruby -v
           rake bundle:clean
           rake bundle:install
-      - name: opensearch
+      - name: opensearch-ruby
         run: cd opensearch && bundle exec rake test_security:all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,8 @@ jobs:
         run: cd opensearch-api && bundle exec rake test:spec
       - name: opensearch-dsl
         run: cd opensearch-dsl && bundle exec rake test:all
+      - name: opensearch-aws-sigv4
+        run: cd opensearch-aws-sigv4 && bundle exec rake test:all
 
   test-opensearch-faraday-1:
     env:
@@ -118,5 +120,5 @@ jobs:
           ruby -v
           rake bundle:clean
           rake bundle:install
-      - name: opensearch
+      - name: opensearch-ruby
         run: cd opensearch && bundle exec rake test_security:all

--- a/.github/workflows/test-unreleased.yml
+++ b/.github/workflows/test-unreleased.yml
@@ -62,3 +62,5 @@ jobs:
         run: cd opensearch-api && bundle exec rake test:spec
       - name: opensearch-dsl
         run: cd opensearch-dsl && bundle exec rake test:all
+      - name: opensearch-aws-sigv4
+        run: cd opensearch-aws-sigv4 && bundle exec rake test:all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Github workflow for changelog verification ([#102](https://github.com/opensearch-project/opensearch-ruby/pull/102))
+- Added Sigv4 Support with `opensearch-aws-sigv4` gem ([#71](https://github.com/opensearch-project/opensearch-ruby/issues/71))
 
 ### Changed
 
@@ -12,7 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
-- Mocha Dependency issue in `opensearch-dsl` gem ([#108](https://github.com/opensearch-project/opensearch-ruby/pull/108))
+- Locked Mocha Gem down to version 1.x.x in `opensearch-dsl` gem ([#108](https://github.com/opensearch-project/opensearch-ruby/pull/108))
  
 ### Security
 

--- a/Rakefile
+++ b/Rakefile
@@ -54,12 +54,14 @@ SUBPROJECTS = [
   'opensearch-transport',
   'opensearch-dsl',
   'opensearch-api',
+  'opensearch-aws-sigv4',
 ].freeze
 
 RELEASE_TOGETHER = [
   'opensearch',
   'opensearch-transport',
   'opensearch-api',
+  'opensearch-aws-sigv4',
 ].freeze
 
 CERT_DIR = ENV['CERT_DIR']

--- a/opensearch-aws-sigv4/.gitignore
+++ b/opensearch-aws-sigv4/.gitignore
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+*.gem
+*.rbc
+.bundle
+.config
+.yardoc
+.ruby-version
+.idea/
+Gemfile.lock
+InstalledFiles
+_yardoc
+coverage
+doc/
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp

--- a/opensearch-aws-sigv4/Gemfile
+++ b/opensearch-aws-sigv4/Gemfile
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in opensearch-aws-sigv4.gemspec
+gemspec
+
+if File.exist? File.expand_path("../../opensearch-api/opensearch-api.gemspec", __FILE__)
+  gem 'opensearch-api', :path => File.expand_path("../../opensearch-api", __FILE__), :require => false
+end
+
+if File.exist? File.expand_path("../../opensearch-transport/opensearch-transport.gemspec", __FILE__)
+  gem 'opensearch-transport', :path => File.expand_path("../../opensearch-transport", __FILE__), :require => false
+end
+
+if File.exist? File.expand_path("../../opensearch/opensearch.gemspec", __FILE__)
+  gem 'opensearch-ruby', :path => File.expand_path("../../opensearch", __FILE__), :require => false
+end

--- a/opensearch-aws-sigv4/LICENSE
+++ b/opensearch-aws-sigv4/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/opensearch-aws-sigv4/README.md
+++ b/opensearch-aws-sigv4/README.md
@@ -1,0 +1,63 @@
+# OpenSearch Aws Sigv4 Client
+
+The `opensearch-aws-sigv4` library provides an AWS Sigv4 client for [OpenSearch](http://opensearch.com).
+
+## Compatibility
+
+The OpenSearch Aws Sigv4 Client is compatible with Ruby 2.5 and higher.
+
+The client's API is compatible with OpenSearch's API versions from 1.0.0 till current.
+
+See [COMPATIBILITY](../COMPATIBILITY.md) for more details.
+
+## Installation
+
+Install the package from [Rubygems](https://rubygems.org):
+
+    gem install opensearch-aws-sigv4
+
+To use an unreleased version, either add it to your `Gemfile` for [Bundler](http://gembundler.com):
+
+    gem 'opensearch-aws-sigv4', git: 'git://github.com/opensearch-project/opensearch-ruby.git'
+
+or install it from a source code checkout:
+
+    git clone https://github.com/opensearch-project/opensearch-ruby
+    cd opensearch-ruby/opensearch-aws-sigv4
+    bundle install
+    rake install
+
+## Usage
+
+This library is an AWS Sigv4 wrapper for 
+[`opensearch-ruby`](https://github.com/opensearch-project/opensearch-ruby/tree/main/opensearch),
+which is a Ruby client for OpenSearch. The `OpenSearch::Aws::Sigv4Client` is, therefore, has all features of `OpenSearch::Client`.
+And since `opensearch-ruby` is a dependency of `opensearch-aws-sigv4`, you only need to install `opensearch-aws-sigv4`.
+
+```ruby
+require 'opensearch-aws-sigv4'
+require 'aws-sigv4'
+
+signer = Aws::Sigv4::Signer.new(service: 'es',
+                                region: 'us-west-2',
+                                access_key_id: 'key_id',
+                                secret_access_key: 'secret')
+
+client = OpenSearch::Aws::Sigv4Client.new({ log: true }, signer)
+
+client.cluster.health
+
+client.transport.reload_connections!
+
+client.search q: 'test'
+```
+
+Please refer to [opensearch-ruby](https://github.com/opensearch-project/opensearch-ruby/blob/main/opensearch/README.md) documentation for further details.
+
+## Development
+
+You can run `rake -T` to check the test tasks. Use `COVERAGE=true` before running a test task to check the coverage with Simplecov.
+
+## License
+
+This software is licensed under the [Apache 2 license](./LICENSE).

--- a/opensearch-aws-sigv4/Rakefile
+++ b/opensearch-aws-sigv4/Rakefile
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+require 'bundler/gem_tasks'
+
+task(:default) { system 'rake --tasks' }
+
+desc 'Run unit tests'
+task test: 'test:spec'
+
+# ----- Test tasks ------------------------------------------------------------
+require 'rspec/core/rake_task'
+
+namespace :test do
+  RSpec::Core::RakeTask.new(:integration) do |t|
+    t.pattern = 'spec/integration/**{,/*/**}/*_spec.rb'
+  end
+
+  RSpec::Core::RakeTask.new(:unit) do |t|
+    t.pattern = 'spec/unit/**{,/*/**}/*_spec.rb'
+  end
+
+  desc 'Run unit and integration tests'
+  task :all do
+    Rake::Task['test:unit'].invoke
+    Rake::Task['test:integration'].invoke
+  end
+end
+
+# ----- Documentation tasks ---------------------------------------------------
+
+require 'yard'
+YARD::Rake::YardocTask.new(:doc) do |t|
+  t.options = %w| --embed-mixins --markup=markdown |
+end

--- a/opensearch-aws-sigv4/bin/opensearch_ruby_console
+++ b/opensearch-aws-sigv4/bin/opensearch_ruby_console
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift(File.expand_path('../../opensearch-aws-sigv4/lib', __dir__))
+$LOAD_PATH.unshift(File.expand_path('../../opensearch-transport/lib', __dir__))
+$LOAD_PATH.unshift(File.expand_path('../../opensearch-dsl/lib', __dir__))
+$LOAD_PATH.unshift(File.expand_path('../../opensearch-api/lib', __dir__))
+
+require 'opensearch-aws-sigv4'
+require 'opensearch-transport'
+require 'opensearch-api'
+
+gems_not_loaded = ['opensearch-dsl'].reject do |gem|
+  begin
+    (require gem) || true
+  rescue LoadError
+    false
+  end
+end
+
+unless gems_not_loaded.empty?
+  warn "The following gems were not loaded: [#{gems_not_loaded.join(', ')}]. Please install and require them explicitly."
+end
+
+include OpenSearch
+include OpenSearch::DSL if defined?(OpenSearch::DSL)
+
+begin
+  require 'pry'
+rescue LoadError
+end
+
+begin
+  require 'irb'
+rescue LoadError
+end
+
+if defined?(Pry)
+  Pry.config.prompt_name = 'opensearch_ruby'
+  Pry.start
+elsif defined?(IRB)
+  IRB.start
+else
+  abort 'LoadError: opensearch_ruby_console requires Pry or IRB'
+end

--- a/opensearch-aws-sigv4/lib/opensearch-aws-sigv4.rb
+++ b/opensearch-aws-sigv4/lib/opensearch-aws-sigv4.rb
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+require 'opensearch-ruby'
+require 'aws-sigv4/signer'
+require 'faraday'
+require 'json'
+
+module OpenSearch
+  module Aws
+    # AWS Sigv4 Wrapper for OpenSearch::Client.
+    # This client accepts a Sigv4 Signer during initialization, and signs every request
+    # with a Sigv4 Signature with the provided signer.
+    #
+    # @example
+    #   signer = Aws::Sigv4::Signer.new(service: 'es',
+    #                                   region: 'us-east-1',
+    #                                   access_key_id: '<access_key_id>',
+    #                                   secret_access_key: '<secret_access_key>',
+    #                                   session_token: '<session_token>')
+    #
+    #   client = OpenSearch::Aws::Sigv4Client.new(
+    #       { host: 'https://my-os-domain.us-east-1.es.amazonaws.com/' },
+    #       signer
+    #   )
+    #
+    #   puts client.cat.health
+    #
+    # @attr [Aws::Sigv4::Signer] sigv4_signer Signer used to sign every request
+    class Sigv4Client < ::OpenSearch::Client
+      attr_accessor :sigv4_signer
+
+      # @param [Hash] transport_args arguments for OpenSearch::Transport::Client.
+      # @param [&block] block code block to be passed to OpenSearch::Transport::Client.
+      # @param [Aws::Sigv4::Signer] sigv4_signer an instance of AWS Sigv4 Signer.
+      def initialize(transport_args = {}, sigv4_signer, &block)
+        unless sigv4_signer.is_a?(::Aws::Sigv4::Signer)
+          raise ArgumentError, "Please pass a Aws::Sigv4::Signer. A #{sigv4_signer.class} was given."
+        end
+
+        @sigv4_signer = sigv4_signer
+        super transport_args, &block
+      end
+
+      # @see OpenSearch::Transport::Transport::Base::perform_request
+      def perform_request(method, path, params = {}, body = nil, headers = nil)
+        verify_open_search unless @verified
+        signature_body = body.is_a?(Hash) ? body.to_json : body.to_s
+        signature = sigv4_signer.sign_request(
+          http_method: method,
+          url: signature_url(path, params),
+          headers: headers,
+          body: signature_body)
+        headers = (headers || {}).merge(signature.headers)
+        @transport.perform_request(method, path, params, body, headers)
+      end
+
+      private
+
+      def signature_url(path, params)
+        host = @transport.transport.hosts.dig(0, :host)
+        path = '/' + path unless path.start_with?('/')
+        query_string = params.empty? ? '' : "#{Faraday::Utils::ParamsHash[params].to_query}"
+        URI::HTTP.build(host: host, path: path, query: query_string)
+      end
+    end
+  end
+end

--- a/opensearch-aws-sigv4/lib/opensearch-aws-sigv4/version.rb
+++ b/opensearch-aws-sigv4/lib/opensearch-aws-sigv4/version.rb
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+module OpenSearch
+  module Aws
+    module Sigv4
+      VERSION = '1.0.0'.freeze
+    end
+  end
+end

--- a/opensearch-aws-sigv4/opensearch-aws-sigv4.gemspec
+++ b/opensearch-aws-sigv4/opensearch-aws-sigv4.gemspec
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opensearch-aws-sigv4/version'
+
+signing_key_path = File.expand_path("../gem-private_key.pem")
+
+Gem::Specification.new do |s|
+  s.name          = 'opensearch-aws-sigv4'
+  s.version       = OpenSearch::Aws::Sigv4::VERSION
+  s.authors       = ['Theo Truong']
+  s.email         = ['theo.nam.truong@gmail.com']
+  s.summary       = 'Ruby AWS Sigv4 Client for OpenSearch'
+  s.homepage      = 'https://opensearch.org/docs/latest'
+  s.license       = 'Apache-2.0'
+  s.metadata = {
+    'homepage_uri' => 'https://opensearch.org/docs/latest/',
+    'source_code_uri' => 'https://github.com/opensearch-project/opensearch-ruby/tree/main',
+    'bug_tracker_uri' => 'https://github.com/opensearch-project/opensearch-ruby/issues'
+  }
+  s.files         = `git ls-files`.split($/)
+  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  s.executables   << 'opensearch_ruby_console'
+  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+
+  if $PROGRAM_NAME.end_with?("gem") && ARGV == ["build", __FILE__] && File.exist?(signing_key_path)
+    s.signing_key = signing_key_path
+    s.cert_chain  = ['../certs/opensearch-rubygems.pem']
+  end
+
+  s.require_paths = ['lib']
+  s.bindir = 'bin'
+
+  s.extra_rdoc_files  = [ 'README.md', 'LICENSE' ]
+  s.rdoc_options      = [ '--charset=UTF-8' ]
+
+  s.required_ruby_version = '>= 2.5'
+
+  s.add_dependency 'aws-sigv4',  '~> 1'
+  s.add_dependency 'opensearch-ruby', '>= 1.0.1'
+
+  s.add_development_dependency 'bundler'
+  s.add_development_dependency 'byebug' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'rake', '~> 13'
+  s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'ruby-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'yard'
+  s.add_development_dependency 'timecop'
+
+  s.description = <<-DESC.gsub(/^    /, '')
+    Ruby AWS Sigv4 Client for OpenSearch
+  DESC
+end

--- a/opensearch-aws-sigv4/spec/integration/sigv4_client_integration_spec.rb
+++ b/opensearch-aws-sigv4/spec/integration/sigv4_client_integration_spec.rb
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+require_relative '../spec_helper'
+require 'logger'
+require 'aws-sigv4'
+
+describe OpenSearch::Aws::Sigv4Client do
+  let(:client) do
+    signer = Aws::Sigv4::Signer.new(service: 'es',
+                                    region: 'us-west-2',
+                                    access_key_id: 'key_id',
+                                    secret_access_key: 'secret')
+
+    OpenSearch::Aws::Sigv4Client.new({ host: OPENSEARCH_URL, logger: Logger.new($stdout) }, signer)
+  end
+
+  it 'performs API actions without throwing any errors' do
+    expect do
+      # Index a document
+      client.index(index: 'test-index', id: '1', body: { title: 'Test' })
+
+      # Refresh the index
+      client.indices.refresh(index: 'test-index')
+
+      # Search
+      response = client.search(index: 'test-index', body: { query: { match: { title: 'test' } } })
+
+      expect(response['hits']['total']['value']).to eq 1
+      expect(response['hits']['hits'][0]['_source']['title']).to eq 'Test'
+
+      # Delete the index
+      client.indices.delete(index: 'test-index')
+    end.not_to raise_error
+  end
+end

--- a/opensearch-aws-sigv4/spec/spec_helper.rb
+++ b/opensearch-aws-sigv4/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+require 'opensearch-aws-sigv4'
+require 'rspec'
+
+OPENSEARCH_URL = ENV['TEST_OPENSEARCH_SERVER'] || "http://localhost:#{(ENV['PORT'] || 9200)}"
+raise URI::InvalidURIError unless OPENSEARCH_URL =~ /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
+
+RSpec.configure do |config|
+  config.formatter = :documentation
+end

--- a/opensearch-aws-sigv4/spec/unit/sigv4_client_spec.rb
+++ b/opensearch-aws-sigv4/spec/unit/sigv4_client_spec.rb
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+require_relative '../spec_helper'
+require 'aws-sigv4'
+require 'timecop'
+
+describe OpenSearch::Aws::Sigv4Client do
+  subject(:client) do
+    OpenSearch::Aws::Sigv4Client.new(
+      { host: 'http://localhost:9200',
+        transport_options: { ssl: { verify: false } } },
+      signer)
+  end
+
+  let(:signer) do
+    Aws::Sigv4::Signer.new(service: 'es',
+                           region: 'us-west-2',
+                           access_key_id: 'key_id',
+                           secret_access_key: 'secret')
+  end
+
+  describe '.initialize' do
+    context 'when a Sigv4 Signer is NOT provided' do
+      let(:signer) { nil }
+
+      it 'raises an argument error' do
+        expect { client }.to raise_error ArgumentError, 'Please pass a Aws::Sigv4::Signer. A NilClass was given.'
+      end
+    end
+
+    context 'when a Sigv4 Signer is provided' do
+      it 'does NOT raise any error' do
+        expect { client }.to_not raise_error
+      end
+    end
+  end
+
+  describe '#perform_request' do
+    let(:response) { { body: 'Response Body' } }
+    let(:transport_double) do
+      _double = instance_double('OpenSearch::Transport::Client', perform_request: response)
+      _double.stub_chain(:transport, :hosts, :dig).and_return('localhost')
+      _double
+    end
+    let(:signed_headers) do
+       { 'authorization' => 'AWS4-HMAC-SHA256 Credential=key_id/20220101/us-west-2/es/aws4_request, '\
+                            'SignedHeaders=host;x-amz-content-sha256;x-amz-date, ' \
+                            'Signature=9c4c690110483308f62a91c2ca873857750bca2607ba1aabdae0d2303950310a',
+         'host' => 'localhost',
+         'x-amz-content-sha256' => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+         'x-amz-date' => '20220101T000000Z' }
+    end
+    
+    before(:each) do
+      Timecop.freeze(Time.utc(2022))
+      allow(client).to receive(:verify_open_search) { true }
+      client.transport = transport_double
+    end
+
+    after(:each) { Timecop.return }
+
+    it 'signs the request before passing it to @transport' do
+      output = client.perform_request('GET', '/', {}, '', {})
+      expect(output).to eq(response)
+      expect(transport_double).to have_received(:perform_request).with('GET', '/', {}, '', signed_headers)
+    end
+  end
+end


### PR DESCRIPTION
### Description
Added Sigv4 Client gem that is a wrapper of `opensearch-ruby` gem. This gem will sign every request with an AWS Sigv4 signature.

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-ruby/issues/71

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).