### PR TITLE
Bump jenkins lib version to acommodate signed gem verification bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix token permissions on GitHub release drafter workflow ([#119](https://github.com/opensearch-project/opensearch-ruby/pull/119))
 - Fix token permissions so that it can create a GitHub release ([#120](https://github.com/opensearch-project/opensearch-ruby/pull/120))
 - Bump jenkins library version to accomodate bug fix ([#121](https://github.com/opensearch-project/opensearch-ruby/pull/121))
- 
+- Bump jenkins library version to accomodate bug fix for signed gem verification ([#122](https://github.com/opensearch-project/opensearch-ruby/pull/122))
+
 ### Security
 
 

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.4.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@1.4.2', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
See https://github.com/opensearch-project/opensearch-build-libraries/pull/56 for details what the bug fix is about. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
