### PR TITLE
[CVE] Replaced `opensearch` with `opensearch-ruby` as dev dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update the public key ([118](https://github.com/opensearch-project/opensearch-ruby/pull/118))
 - Renamed opensearch sigv4 console to avoid conflict with opensearch-ruby when both are installed ([#124](https://github.com/opensearch-project/opensearch-ruby/pull/124))
 - Bumped version for dsl and transport gem ([#125](https://github.com/opensearch-project/opensearch-ruby/pull/125))
+- Replaced `opensearch` with `opensearch-ruby` as dev dependency ([#128](https://github.com/opensearch-project/opensearch-ruby/issues/128))
 ### Deprecated
 
 ### Removed

--- a/opensearch-api/opensearch-api.gemspec
+++ b/opensearch-api/opensearch-api.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'ansi'
   s.add_development_dependency 'bundler'
-  s.add_development_dependency 'opensearch'
+  s.add_development_dependency 'opensearch-ruby', '~> 2'
   s.add_development_dependency 'opensearch-transport'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-reporters'
@@ -86,6 +86,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ruby-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
 
   s.description = <<-DESC.gsub(/^    /, '')
-    Ruby API for OpenSearch. See the `opensearch` gem for full integration.
+    Ruby API for OpenSearch. See the `opensearch-ruby` gem for full integration.
   DESC
 end

--- a/opensearch-dsl/opensearch-dsl.gemspec
+++ b/opensearch-dsl/opensearch-dsl.gemspec
@@ -63,9 +63,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake', '~> 13'
-
-  s.add_development_dependency 'opensearch'
-
+  s.add_development_dependency 'opensearch-ruby', '~> 2'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'minitest-reporters', '~> 1'

--- a/opensearch-transport/opensearch-transport.gemspec
+++ b/opensearch-transport/opensearch-transport.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'curb' unless defined? JRUBY_VERSION
-  s.add_development_dependency 'opensearch-ruby'
+  s.add_development_dependency 'opensearch-ruby', '~> 2'
   s.add_development_dependency 'hashie'
   s.add_development_dependency 'httpclient'
   s.add_development_dependency 'faraday-httpclient'
@@ -91,6 +91,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard'
 
   s.description = <<-DESC.gsub(/^    /, '')
-    Ruby client for OpenSearch. See the `opensearch` gem for full integration.
+    Ruby client for OpenSearch. See the `opensearch-ruby` gem for full integration.
   DESC
 end


### PR DESCRIPTION
Solving: CVE-2022-31115

Signed-off-by: Theo Truong <theotr@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
