### PR TITLE
Sign validation request when using aws-sigv4 (#130)

### DIFF
--- a/opensearch-aws-sigv4/CHANGELOG.md
+++ b/opensearch-aws-sigv4/CHANGELOG.md
@@ -7,6 +7,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Sign validation requests when using AWS Sigv4 ([#134](https://github.com/opensearch-project/opensearch-ruby/pull/134))
+
 ### Security
 
 ## 1.0.0

--- a/opensearch-aws-sigv4/opensearch-aws-sigv4.gemspec
+++ b/opensearch-aws-sigv4/opensearch-aws-sigv4.gemspec
@@ -16,8 +16,8 @@ signing_key_path = File.expand_path("../gem-private_key.pem")
 Gem::Specification.new do |s|
   s.name          = 'opensearch-aws-sigv4'
   s.version       = OpenSearch::Aws::Sigv4::VERSION
-  s.authors       = ['Theo Truong']
-  s.email         = ['theo.nam.truong@gmail.com']
+  s.authors       = ['Theo Truong', 'Robin Roestenburg']
+  s.email         = ['theo.nam.truong@gmail.com', 'robin.roestenburg@4me.com']
   s.summary       = 'Ruby AWS Sigv4 Client for OpenSearch'
   s.homepage      = 'https://opensearch.org/docs/latest'
   s.license       = 'Apache-2.0'

--- a/opensearch-aws-sigv4/spec/unit/sigv4_client_spec.rb
+++ b/opensearch-aws-sigv4/spec/unit/sigv4_client_spec.rb
@@ -45,31 +45,62 @@ describe OpenSearch::Aws::Sigv4Client do
   describe '#perform_request' do
     let(:response) { { body: 'Response Body' } }
     let(:transport_double) do
-      _double = instance_double('OpenSearch::Transport::Client', perform_request: response)
+      _double = instance_double('OpenSearch::Transport::Client')
       _double.stub_chain(:transport, :hosts, :dig).and_return('localhost')
       _double
     end
     let(:signed_headers) do
-       { 'authorization' => 'AWS4-HMAC-SHA256 Credential=key_id/20220101/us-west-2/es/aws4_request, '\
-                            'SignedHeaders=host;x-amz-content-sha256;x-amz-date, ' \
-                            'Signature=9c4c690110483308f62a91c2ca873857750bca2607ba1aabdae0d2303950310a',
-         'host' => 'localhost',
-         'x-amz-content-sha256' => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-         'x-amz-date' => '20220101T000000Z' }
+       {
+        'authorization' => 'AWS4-HMAC-SHA256 Credential=key_id/20220101/us-west-2/es/aws4_request, '\
+                           'SignedHeaders=host;x-amz-content-sha256;x-amz-date, ' \
+                           'Signature=5c04a328341dbdaf5c74d329d814815fda6ea53ba1e7191cdbc4cd21df834c3f',
+        'host' => 'localhost',
+        'x-amz-content-sha256' => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        'x-amz-date' => '20220101T000000Z'
+      }
     end
-    
+
     before(:each) do
       Timecop.freeze(Time.utc(2022))
-      allow(client).to receive(:verify_open_search) { true }
       client.transport = transport_double
     end
 
     after(:each) { Timecop.return }
 
-    it 'signs the request before passing it to @transport' do
-      output = client.perform_request('GET', '/', {}, '', {})
-      expect(output).to eq(response)
-      expect(transport_double).to have_received(:perform_request).with('GET', '/', {}, '', signed_headers)
+    context 'with verified opensearch distribution' do
+      before(:each) do
+        client.instance_variable_set(:@verified, true)
+        allow(transport_double).to receive(:perform_request).with('GET', '/_stats', {}, '', signed_headers) { response }
+      end
+
+      it 'does not verify opensearch distribution again' do
+        expect(client).to_not receive(:verify_open_search)
+        output = client.perform_request('GET', '/_stats', {}, '', {})
+      end
+
+      it 'signs the request before passing it to @transport' do
+        expect(transport_double).to receive(:perform_request).with('GET', '/_stats', {}, '', signed_headers)
+        output = client.perform_request('GET', '/_stats', {}, '', {})
+        expect(output).to eq(response)
+      end
+    end
+
+    context 'with unverified opensearch distribution' do
+      before(:each) do
+        stub_sigv4_signer = double
+        allow(stub_sigv4_signer).to receive(:sign_request) { OpenStruct.new(headers: signed_headers) }
+        client.sigv4_signer = stub_sigv4_signer
+      end
+
+      it 'verifies opensearch distribution' do
+        verification_response = OpenStruct.new({
+          headers: {},
+          body: { 'version' => { 'number' => '1.0.0', 'distribution' => 'opensearch' } },
+        })
+        expect(transport_double).to receive(:perform_request).with('GET', '/', {}, nil, signed_headers).ordered { verification_response }
+        expect(transport_double).to receive(:perform_request).with('GET', '/_stats', {}, '', signed_headers).ordered { response }
+        output = client.perform_request('GET', '/_stats', {}, '', {})
+      end
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Robin Roestenburg <robin.roestenburg@4me.com>

### Description
Fixes #130 by having the `opensearch-aws-sigv4` gem pass the signing headers to the request to verify / validate the OpenSearch distribution. 

When you do not use the AWS v4 signing, the behaviour of the `opensearch-ruby` gem is unchanged. The `verify_open_search` method is called without passing any headers (as before).

### Issues Resolved
Closes #130. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
