### PR TITLE
CI: add Ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
+        ruby: [ 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/opensearch-api/Rakefile
+++ b/opensearch-api/Rakefile
@@ -88,7 +88,7 @@ namespace :test do
     filename = 'tmp/artifacts.json'
     `curl -s <placeholder_opensearch_artifact_url> -o #{filename}`
 
-    unless File.exists?("./#{filename}")
+    unless File.exist?("./#{filename}")
       STDERR.puts '[!] Couldn\'t download artifacts file'
       exit 1
     end
@@ -105,7 +105,7 @@ namespace :test do
     puts 'Downloading zip file:'
     `curl -s #{zip_url} -o tmp/#{filename}`
 
-    unless File.exists?("./tmp/#{filename}")
+    unless File.exist?("./tmp/#{filename}")
       STDERR.puts '[!] Couldn\'t download artifact'
       exit 1
     end

--- a/profile/benchmarking/benchmarking_tasks.rake
+++ b/profile/benchmarking/benchmarking_tasks.rake
@@ -173,7 +173,7 @@ namespace :benchmark do
     task :download_dataset do
       current_path = File.expand_path(File.dirname(__FILE__))
       data_path = [current_path, 'data'].join('/')
-      unless File.exists?([data_path, 'stackoverflow.json'].join('/'))
+      unless File.exist?([data_path, 'stackoverflow.json'].join('/'))
         `gsutil cp gs://clients-team-files/stackoverflow.json "#{data_path}/"`
       end
     end

--- a/rake_tasks/test_tasks.rake
+++ b/rake_tasks/test_tasks.rake
@@ -108,7 +108,7 @@ namespace :test do
     end
     puts "Successfully downloaded #{filename}"
 
-    unless File.exists?(filename)
+    unless File.exist?(filename)
       STDERR.puts "[!] Couldn't download #{filename}"
       exit 1
     end


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the build matrix for confidence in compatibility.

The deprecated method `File.exists?` has been removed in Ruby 3.2. I've replaced occurrences with `File.exist?`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

