### PR TITLE
Add 2PR approval to release workflow

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -11,9 +11,21 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      issues: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+      - id: get_approvers
+        run: |
+          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: ${{ steps.get_approvers.outputs.approvers }}
+          minimum-approvals: 2
+          issue-title: "Release ${{ github.ref_name }}"
+          issue-body: "Please approve or deny the release **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
+          exclude-workflow-initiator-as-approver: true
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,7 +34,8 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md). For this client, there are 5 gems that can be released: `opensearch-api`, `opensearch-ruby`, `opensearch-transport`, `opensearch-dsl` and `opensearch-aws-sigv4`.
 
 1. Create a tag for the releasing ruby gem, e.g. `opensearch-ruby/2.2.0`, and push it to the GitHub repo.
-2. The [release-drafter.yml](.github/workflows/release_drafter.yml) will be automatically kicked off and a draft release will be created.
-3. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-ruby-gems-release/) as a result of which opensearch-ruby client gem is released on rubygems.
-4. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
-5. Increment "version" in related gems `version.rb` to the next patch release, e.g. v2.2.1.
+1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and is responsible for drafting a new release on GitHub containing release artifacts.
+1. Before creating a draft release, this workflow creates a GitHub issue asking for approval from the [maintainers](MAINTAINERS.md). See sample [issue](https://github.com/gaiksaya/opensearch-ruby/issues/1). The maintainers need to approve in order to continue the workflow run.
+1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-ruby-gems-release/) as a result of which opensearch-ruby client gem is released on rubygems.
+1. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+1. Increment "version" in related gems `version.rb` to the next patch release, e.g. v2.2.1.


### PR DESCRIPTION
### Description
This change retrieves the codeowner's list from .github/codeowners file and adds them as approvers for releasing opensearch-ruby
Here is a sample issue that is created when this workflow runs: https://github.com/gaiksaya/opensearch-ruby/issues/1
Once approved, the workflow continues to run as usual.
Note: This approval duration is subject to the broader 72 hours timeout for a workflow.

### Issues Resolved
related https://github.com/opensearch-project/opensearch-build/issues/3111

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
