### PR TITLE
[CODE_GEN] Added `remote_store.restore` action

### DIFF
--- a/.github/license-header.txt
+++ b/.github/license-header.txt
@@ -3,6 +3,3 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-#
-# Modifications Copyright OpenSearch Contributors. See
-# GitHub history for details.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,9 @@ Layout/EmptyLineAfterGuardClause:
 
 Naming/FileName:
   Enabled: false
+
+Layout/FirstArgumentIndentation:
+  Enabled: false
+
+Layout/FirstArrayElementIndentation:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- `remote_store.restore` action ([#176](https://github.com/opensearch-project/opensearch-ruby/pull/176))
 ### Changed
 - Merged `opensearch-transport`, `opensearch-api`, and `opensearch-dsl` into `opensearch-ruby` ([#133](https://github.com/opensearch-project/opensearch-ruby/issues/133))
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- `remote_store.restore` action ([#176](https://github.com/opensearch-project/opensearch-ruby/pull/176))
+- Added `remote_store.restore` action ([#176](https://github.com/opensearch-project/opensearch-ruby/pull/176))
 ### Changed
 - Merged `opensearch-transport`, `opensearch-api`, and `opensearch-dsl` into `opensearch-ruby` ([#133](https://github.com/opensearch-project/opensearch-ruby/issues/133))
 ### Deprecated

--- a/guides/transport_options.md
+++ b/guides/transport_options.md
@@ -389,7 +389,7 @@ The serialization component is pluggable, though, so you can write your own by i
 
 ### Exception Handling
 
-The library defines a [number of exception classes](https://github.com/opensearch-project/opensearch-ruby/blob/main/opensearch-transport/lib/opensearch/transport/transport/errors.rb) for various client and server errors, as well as unsuccessful HTTP responses, making it possible to `rescue` specific exceptions with desired granularity.
+The library defines a [number of exception classes](../lib/opensearch/transport/transport/errors.rb) for various client and server errors, as well as unsuccessful HTTP responses, making it possible to `rescue` specific exceptions with desired granularity.
 
 The highest-level exception is {OpenSearch::Transport::Transport::Error} and will be raised for any generic client *or* server errors.
 

--- a/lib/opensearch/api.rb
+++ b/lib/opensearch/api.rb
@@ -6,7 +6,7 @@
 #
 # Modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
-
+#
 # Licensed to Elasticsearch B.V. under one or more contributor
 # license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright

--- a/lib/opensearch/api.rb
+++ b/lib/opensearch/api.rb
@@ -6,7 +6,7 @@
 #
 # Modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
-#
+
 # Licensed to Elasticsearch B.V. under one or more contributor
 # license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright
@@ -24,8 +24,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'cgi'
-require 'multi_json'
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
 
 require 'opensearch/api/namespace/common'
 require 'opensearch/api/utils'
@@ -57,42 +59,42 @@ module OpenSearch
       :opaque_id                      # Use X-Opaque-Id
     ]
 
-    HTTP_GET          = 'GET'.freeze
-    HTTP_HEAD         = 'HEAD'.freeze
-    HTTP_POST         = 'POST'.freeze
-    HTTP_PUT          = 'PUT'.freeze
-    HTTP_DELETE       = 'DELETE'.freeze
-    UNDERSCORE_SEARCH = '_search'.freeze
-    UNDERSCORE_ALL    = '_all'.freeze
-    DEFAULT_DOC       = '_doc'.freeze
+    HTTP_GET          = 'GET'
+    HTTP_HEAD         = 'HEAD'
+    HTTP_PATCH        = 'PATCH'
+    HTTP_POST         = 'POST'
+    HTTP_PUT          = 'PUT'
+    HTTP_DELETE       = 'DELETE'
+
+    UNDERSCORE_SEARCH = '_search'
+    UNDERSCORE_ALL    = '_all'
+    DEFAULT_DOC       = '_doc'
 
     # Auto-include all namespaces in the receiver
-    #
     def self.included(base)
       base.send :include,
                 OpenSearch::API::Common,
                 OpenSearch::API::Actions,
-                OpenSearch::API::Cluster,
-                OpenSearch::API::Nodes,
-                OpenSearch::API::Indices,
-                OpenSearch::API::Ingest,
-                OpenSearch::API::Snapshot,
-                OpenSearch::API::Tasks,
                 OpenSearch::API::Cat,
-                OpenSearch::API::Remote,
+                OpenSearch::API::Cluster,
                 OpenSearch::API::DanglingIndices,
                 OpenSearch::API::Features,
-                OpenSearch::API::Shutdown
+                OpenSearch::API::Indices,
+                OpenSearch::API::Ingest,
+                OpenSearch::API::Nodes,
+                OpenSearch::API::Remote,
+                OpenSearch::API::RemoteStore,
+                OpenSearch::API::Shutdown,
+                OpenSearch::API::Snapshot,
+                OpenSearch::API::Tasks
     end
 
     # The serializer class
-    #
     def self.serializer
       settings[:serializer] || DEFAULT_SERIALIZER
     end
 
     # Access the module settings
-    #
     def self.settings
       @settings ||= {}
     end

--- a/lib/opensearch/api/actions/remote_store/restore.rb
+++ b/lib/opensearch/api/actions/remote_store/restore.rb
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module RemoteStore
+      module Actions
+        RESTORE_QUERY_PARAMS = Set.new(%i[
+          cluster_manager_timeout
+          wait_for_completion
+        ]).freeze
+
+        # Restores from remote store.
+        #
+        # @option arguments [Time] :cluster_manager_timeout Operation timeout for connection to cluster-manager node.
+        # @option arguments [Boolean] :wait_for_completion Should this request wait until the operation has completed before returning.
+        # @option arguments [Hash] :body *Required* Comma-separated list of index IDs
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/opensearch/remote/#restoring-from-a-backup]
+        def restore(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_remotestore', '_restore'
+          method  = OpenSearch::API::HTTP_POST
+          params  = Utils.__validate_and_extract_params arguments, RESTORE_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/remote_store/restore.rb
+++ b/lib/opensearch/api/actions/remote_store/restore.rb
@@ -3,9 +3,6 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-#
-# Modifications Copyright OpenSearch Contributors. See
-# GitHub history for details.
 
 # This code was generated from OpenSearch API Spec.
 # Update the code generation logic instead of modifying this file directly.

--- a/lib/opensearch/api/namespace/remote_store.rb
+++ b/lib/opensearch/api/namespace/remote_store.rb
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module RemoteStore
+      module Actions; end
+
+      # Client for the "remote_store" namespace (includes the RemoteStore::Actions methods)
+      class RemoteStoreClient
+        include RemoteStore::Actions
+        include Common::Client
+        include Common::Client::Base
+      end
+
+      # Proxy method for RemoteStoreClient, available in the receiving object
+      def remote_store
+        @remote_store ||= RemoteStoreClient.new(self)
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/namespace/remote_store.rb
+++ b/lib/opensearch/api/namespace/remote_store.rb
@@ -3,9 +3,6 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-#
-# Modifications Copyright OpenSearch Contributors. See
-# GitHub history for details.
 
 # This code was generated from OpenSearch API Spec.
 # Update the code generation logic instead of modifying this file directly.

--- a/spec/opensearch/api/actions/remote_store/restore_spec.rb
+++ b/spec/opensearch/api/actions/remote_store/restore_spec.rb
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.remote_store#restore' do
+  let(:expected_args) do
+    [
+      'POST',
+      '_remotestore/_restore',
+      { cluster_manager_timeout: '1m',
+        wait_for_completion: true },
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.remote_store.restore
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.remote_store.restore(
+      cluster_manager_timeout: '1m',
+      wait_for_completion: true,
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/remote_store/restore_spec.rb
+++ b/spec/opensearch/api/actions/remote_store/restore_spec.rb
@@ -3,9 +3,6 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-#
-# Modifications Copyright OpenSearch Contributors. See
-# GitHub history for details.
 
 # This code was generated from OpenSearch API Spec.
 # Update the code generation logic instead of modifying this file directly.


### PR DESCRIPTION
### Description
All files, excepts `.rubocop.yml` and `CHANGELOG.md`, were generated by the [API generator](https://github.com/nhtruong/opensearch-ruby-api-generator) I'm working on. Once this has been merged, I'll follow up with a PR for the generator into this repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
