### PR TITLE
[Generated Code] Security API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ profile/**/data/*.json
 dist/
 gem-private_key.pem
 .ruby-version
+*/.idea/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added `remote_store.restore` action ([#176](https://github.com/opensearch-project/opensearch-ruby/pull/176))
 - Added API Generator ([#139](https://github.com/opensearch-project/opensearch-ruby/issues/139))
+- Added Security API through API Generator ([#179](https://github.com/opensearch-project/opensearch-ruby/pull/179))
 ### Changed
 - Merged `opensearch-transport`, `opensearch-api`, and `opensearch-dsl` into `opensearch-ruby` ([#133](https://github.com/opensearch-project/opensearch-ruby/issues/133))
 - Bumped `mocha` gem from 1.x.x to 2.x.x ([#178](https://github.com/opensearch-project/opensearch-ruby/pull/178))

--- a/api_generator/lib/action_generator.rb
+++ b/api_generator/lib/action_generator.rb
@@ -15,14 +15,14 @@ class ActionGenerator < BaseGenerator
   attr_reader :module_name, :method_name, :valid_params_constant_name,
               :method_description, :argument_descriptions, :external_docs
 
-  # Actions that use perform_request_simple_ignore_404
+  # Actions that use perform_request_simple_ignore404
   SIMPLE_IGNORE_404 = %w[exists
                          indices.exists
                          indices.exists_alias
                          indices.exists_template
                          indices.exists_type].to_set.freeze
 
-  # Actions that use perform_request_complex_ignore_404
+  # Actions that use perform_request_complex_ignore404
   COMPLEX_IGNORE_404 = %w[delete
                           get
                           indices.flush_synced
@@ -94,8 +94,8 @@ class ActionGenerator < BaseGenerator
 
   def perform_request
     args = 'method, url, params, body, headers'
-    return "perform_request_simple_ignore_404(#{args})" if SIMPLE_IGNORE_404.include?(@action.group)
-    return "perform_request_complex_ignore_404(#{args}, arguments)" if COMPLEX_IGNORE_404.include?(@action.group)
+    return "perform_request_simple_ignore404(#{args})" if SIMPLE_IGNORE_404.include?(@action.group)
+    return "perform_request_complex_ignore404(#{args}, arguments)" if COMPLEX_IGNORE_404.include?(@action.group)
     return "perform_request_ping(#{args})" if PING.include?(@action.group)
     "perform_request(#{args}).body"
   end

--- a/api_generator/lib/spec_generator.rb
+++ b/api_generator/lib/spec_generator.rb
@@ -54,8 +54,6 @@ class SpecGenerator < BaseGenerator
     action.required_components.map do |component|
       { arg: component,
         others: other_required_components(component) }
-    end.tap do |components|
-      components.last&.update(blank_line: true)
     end
   end
 

--- a/api_generator/templates/spec.mustache
+++ b/api_generator/templates/spec.mustache
@@ -13,6 +13,9 @@ describe 'client{{#namespace}}.{{namespace}}{{/namespace}}#{{name}}' do
       {{#expected_query_params}}
       {{pre}}{{key}}: {{{value}}}{{post}}
       {{/expected_query_params}}
+      {{^expected_query_params}}
+      {},
+      {{/expected_query_params}}
       {{body}},
       {}
     ]
@@ -21,16 +24,14 @@ describe 'client{{#namespace}}.{{namespace}}{{/namespace}}#{{name}}' do
   let(:client) do
     Class.new { include OpenSearch::API }.new
   end
-  {{#required_components}}
 
+  {{#required_components}}
   it 'requires the :{{arg}} argument' do
     expect do
       client{{#namespace}}.{{namespace}}{{/namespace}}.{{name}}{{{others}}}
     end.to raise_exception(ArgumentError)
   end
-  {{#blank_line}}
 
-  {{/blank_line}}
   {{/required_components}}
   it 'performs the request with all optional params' do
     expect(client_double{{#namespace}}.{{namespace}}{{/namespace}}.{{name}}(

--- a/lib/opensearch/api.rb
+++ b/lib/opensearch/api.rb
@@ -84,6 +84,7 @@ module OpenSearch
                 OpenSearch::API::Nodes,
                 OpenSearch::API::Remote,
                 OpenSearch::API::RemoteStore,
+                OpenSearch::API::Security,
                 OpenSearch::API::Shutdown,
                 OpenSearch::API::Snapshot,
                 OpenSearch::API::Tasks

--- a/lib/opensearch/api/actions/security/change_password.rb
+++ b/lib/opensearch/api/actions/security/change_password.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        CHANGE_PASSWORD_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Changes the password for the current user.
+        #
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#change-password]
+        def change_password(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'account'
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, CHANGE_PASSWORD_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/create_action_group.rb
+++ b/lib/opensearch/api/actions/security/create_action_group.rb
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        CREATE_ACTION_GROUP_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Creates or replaces the specified action group.
+        #
+        # @option arguments [String] :action_group *Required* The name of the action group to create or replace
+        # @option arguments [Hash] :body
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#create-action-group]
+        def create_action_group(arguments = {})
+          raise ArgumentError, "Required argument 'action_group' missing" unless arguments[:action_group]
+
+          arguments = arguments.clone
+          _action_group = arguments.delete(:action_group)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'actiongroups', _action_group
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, CREATE_ACTION_GROUP_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/create_role.rb
+++ b/lib/opensearch/api/actions/security/create_role.rb
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        CREATE_ROLE_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Creates or replaces the specified role.
+        #
+        # @option arguments [String] :role *Required*
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#create-role]
+        def create_role(arguments = {})
+          raise ArgumentError, "Required argument 'role' missing" unless arguments[:role]
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          _role = arguments.delete(:role)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'roles', _role
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, CREATE_ROLE_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/create_role_mapping.rb
+++ b/lib/opensearch/api/actions/security/create_role_mapping.rb
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        CREATE_ROLE_MAPPING_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Creates or replaces the specified role mapping.
+        #
+        # @option arguments [String] :role *Required*
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#create-role-mapping]
+        def create_role_mapping(arguments = {})
+          raise ArgumentError, "Required argument 'role' missing" unless arguments[:role]
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          _role = arguments.delete(:role)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'rolesmapping', _role
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, CREATE_ROLE_MAPPING_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/create_tenant.rb
+++ b/lib/opensearch/api/actions/security/create_tenant.rb
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        CREATE_TENANT_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Creates or replaces the specified tenant.
+        #
+        # @option arguments [String] :tenant *Required*
+        # @option arguments [Hash] :body
+        #
+        # {API Reference}[https://opensearch.org/docs/2.7/security/access-control/api/#create-tenant]
+        def create_tenant(arguments = {})
+          raise ArgumentError, "Required argument 'tenant' missing" unless arguments[:tenant]
+
+          arguments = arguments.clone
+          _tenant = arguments.delete(:tenant)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'tenants', _tenant
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, CREATE_TENANT_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/create_user.rb
+++ b/lib/opensearch/api/actions/security/create_user.rb
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        CREATE_USER_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Creates or replaces the specified user.
+        #
+        # @option arguments [String] :username *Required*
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#create-user]
+        def create_user(arguments = {})
+          raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          _username = arguments.delete(:username)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'internalusers', _username
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, CREATE_USER_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/delete_action_group.rb
+++ b/lib/opensearch/api/actions/security/delete_action_group.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        DELETE_ACTION_GROUP_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Delete a specified action group.
+        #
+        # @option arguments [String] :action_group *Required* Action group to delete.
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#delete-action-group]
+        def delete_action_group(arguments = {})
+          raise ArgumentError, "Required argument 'action_group' missing" unless arguments[:action_group]
+
+          arguments = arguments.clone
+          _action_group = arguments.delete(:action_group)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'actiongroups', _action_group
+          method  = OpenSearch::API::HTTP_DELETE
+          params  = Utils.__validate_and_extract_params arguments, DELETE_ACTION_GROUP_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/delete_distinguished_names.rb
+++ b/lib/opensearch/api/actions/security/delete_distinguished_names.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        DELETE_DISTINGUISHED_NAMES_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Deletes all distinguished names in the specified cluster’s or node’s allow list.
+        #
+        # @option arguments [String] :cluster_name *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#delete-distinguished-names]
+        def delete_distinguished_names(arguments = {})
+          raise ArgumentError, "Required argument 'cluster_name' missing" unless arguments[:cluster_name]
+
+          arguments = arguments.clone
+          _cluster_name = arguments.delete(:cluster_name)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'nodesdn', _cluster_name
+          method  = OpenSearch::API::HTTP_DELETE
+          params  = Utils.__validate_and_extract_params arguments, DELETE_DISTINGUISHED_NAMES_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/delete_role.rb
+++ b/lib/opensearch/api/actions/security/delete_role.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        DELETE_ROLE_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Delete the specified role.
+        #
+        # @option arguments [String] :role *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#delete-role]
+        def delete_role(arguments = {})
+          raise ArgumentError, "Required argument 'role' missing" unless arguments[:role]
+
+          arguments = arguments.clone
+          _role = arguments.delete(:role)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'roles', _role
+          method  = OpenSearch::API::HTTP_DELETE
+          params  = Utils.__validate_and_extract_params arguments, DELETE_ROLE_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/delete_role_mapping.rb
+++ b/lib/opensearch/api/actions/security/delete_role_mapping.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        DELETE_ROLE_MAPPING_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Deletes the specified role mapping.
+        #
+        # @option arguments [String] :role *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#delete-role-mapping]
+        def delete_role_mapping(arguments = {})
+          raise ArgumentError, "Required argument 'role' missing" unless arguments[:role]
+
+          arguments = arguments.clone
+          _role = arguments.delete(:role)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'rolesmapping', _role
+          method  = OpenSearch::API::HTTP_DELETE
+          params  = Utils.__validate_and_extract_params arguments, DELETE_ROLE_MAPPING_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/delete_tenant.rb
+++ b/lib/opensearch/api/actions/security/delete_tenant.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        DELETE_TENANT_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Delete the specified tenant.
+        #
+        # @option arguments [String] :tenant *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#delete-action-group]
+        def delete_tenant(arguments = {})
+          raise ArgumentError, "Required argument 'tenant' missing" unless arguments[:tenant]
+
+          arguments = arguments.clone
+          _tenant = arguments.delete(:tenant)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'tenants', _tenant
+          method  = OpenSearch::API::HTTP_DELETE
+          params  = Utils.__validate_and_extract_params arguments, DELETE_TENANT_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/delete_user.rb
+++ b/lib/opensearch/api/actions/security/delete_user.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        DELETE_USER_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Delete the specified user.
+        #
+        # @option arguments [String] :username *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#delete-user]
+        def delete_user(arguments = {})
+          raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
+
+          arguments = arguments.clone
+          _username = arguments.delete(:username)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'internalusers', _username
+          method  = OpenSearch::API::HTTP_DELETE
+          params  = Utils.__validate_and_extract_params arguments, DELETE_USER_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/flush_cache.rb
+++ b/lib/opensearch/api/actions/security/flush_cache.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        FLUSH_CACHE_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Flushes the Security plugin user, authentication, and authorization cache.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/2.7/security/access-control/api/#flush-cache]
+        def flush_cache(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'cache'
+          method  = OpenSearch::API::HTTP_DELETE
+          params  = Utils.__validate_and_extract_params arguments, FLUSH_CACHE_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_account_details.rb
+++ b/lib/opensearch/api/actions/security/get_account_details.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_ACCOUNT_DETAILS_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Returns account details for the current user.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-account-details]
+        def get_account_details(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'account'
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_ACCOUNT_DETAILS_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_action_group.rb
+++ b/lib/opensearch/api/actions/security/get_action_group.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_ACTION_GROUP_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves one action group.
+        #
+        # @option arguments [String] :action_group *Required* Action group to retrieve.
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-action-group]
+        def get_action_group(arguments = {})
+          raise ArgumentError, "Required argument 'action_group' missing" unless arguments[:action_group]
+
+          arguments = arguments.clone
+          _action_group = arguments.delete(:action_group)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'actiongroups', _action_group
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_ACTION_GROUP_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_action_groups.rb
+++ b/lib/opensearch/api/actions/security/get_action_groups.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_ACTION_GROUPS_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves all action groups.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-action-groups]
+        def get_action_groups(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'actiongroups'
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_ACTION_GROUPS_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_audit_configuration.rb
+++ b/lib/opensearch/api/actions/security/get_audit_configuration.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_AUDIT_CONFIGURATION_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves the audit configuration.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#audit-logs]
+        def get_audit_configuration(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'audit'
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_AUDIT_CONFIGURATION_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_certificates.rb
+++ b/lib/opensearch/api/actions/security/get_certificates.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_CERTIFICATES_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves the cluster’s security certificates.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-certificates]
+        def get_certificates(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'ssl', 'certs'
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_CERTIFICATES_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_configuration.rb
+++ b/lib/opensearch/api/actions/security/get_configuration.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_CONFIGURATION_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Returns the current Security plugin configuration in JSON format.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/2.7/security/access-control/api/#get-configuration]
+        def get_configuration(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'securityconfig'
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_CONFIGURATION_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_distinguished_names.rb
+++ b/lib/opensearch/api/actions/security/get_distinguished_names.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_DISTINGUISHED_NAMES_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves all distinguished names in the allow list.
+        #
+        # @option arguments [String] :cluster_name
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-distinguished-names]
+        def get_distinguished_names(arguments = {})
+          arguments = arguments.clone
+          _cluster_name = arguments.delete(:cluster_name)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'nodesdn', _cluster_name
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_DISTINGUISHED_NAMES_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_role.rb
+++ b/lib/opensearch/api/actions/security/get_role.rb
@@ -33,7 +33,7 @@ module OpenSearch
           method  = OpenSearch::API::HTTP_GET
           params  = Utils.__validate_and_extract_params arguments, GET_ROLE_QUERY_PARAMS
 
-          perform_request_complex_ignore_404(method, url, params, body, headers, arguments)
+          perform_request_complex_ignore404(method, url, params, body, headers, arguments)
         end
       end
     end

--- a/lib/opensearch/api/actions/security/get_role.rb
+++ b/lib/opensearch/api/actions/security/get_role.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_ROLE_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves one role.
+        #
+        # @option arguments [String] :role *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-role]
+        def get_role(arguments = {})
+          raise ArgumentError, "Required argument 'role' missing" unless arguments[:role]
+
+          arguments = arguments.clone
+          _role = arguments.delete(:role)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'roles', _role
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_ROLE_QUERY_PARAMS
+
+          perform_request_complex_ignore_404(method, url, params, body, headers, arguments)
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_role_mapping.rb
+++ b/lib/opensearch/api/actions/security/get_role_mapping.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_ROLE_MAPPING_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves one role mapping.
+        #
+        # @option arguments [String] :role *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-role-mapping]
+        def get_role_mapping(arguments = {})
+          raise ArgumentError, "Required argument 'role' missing" unless arguments[:role]
+
+          arguments = arguments.clone
+          _role = arguments.delete(:role)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'rolesmapping', _role
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_ROLE_MAPPING_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_role_mappings.rb
+++ b/lib/opensearch/api/actions/security/get_role_mappings.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_ROLE_MAPPINGS_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves all role mappings.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-role-mappings]
+        def get_role_mappings(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'rolesmapping'
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_ROLE_MAPPINGS_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_roles.rb
+++ b/lib/opensearch/api/actions/security/get_roles.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_ROLES_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves all roles.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-roles]
+        def get_roles(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'roles'
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_ROLES_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_tenant.rb
+++ b/lib/opensearch/api/actions/security/get_tenant.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_TENANT_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves one tenant.
+        #
+        # @option arguments [String] :tenant *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/2.7/security/access-control/api/#get-tenant]
+        def get_tenant(arguments = {})
+          raise ArgumentError, "Required argument 'tenant' missing" unless arguments[:tenant]
+
+          arguments = arguments.clone
+          _tenant = arguments.delete(:tenant)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'tenants', _tenant
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_TENANT_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_tenants.rb
+++ b/lib/opensearch/api/actions/security/get_tenants.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_TENANTS_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieves all tenants.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/2.7/security/access-control/api/#get-tenants]
+        def get_tenants(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'tenants'
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_TENANTS_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_user.rb
+++ b/lib/opensearch/api/actions/security/get_user.rb
@@ -33,7 +33,7 @@ module OpenSearch
           method  = OpenSearch::API::HTTP_GET
           params  = Utils.__validate_and_extract_params arguments, GET_USER_QUERY_PARAMS
 
-          perform_request_complex_ignore_404(method, url, params, body, headers, arguments)
+          perform_request_complex_ignore404(method, url, params, body, headers, arguments)
         end
       end
     end

--- a/lib/opensearch/api/actions/security/get_user.rb
+++ b/lib/opensearch/api/actions/security/get_user.rb
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_USER_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieve one internal user.
+        #
+        # @option arguments [String] :username *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-user]
+        def get_user(arguments = {})
+          raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
+
+          arguments = arguments.clone
+          _username = arguments.delete(:username)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'internalusers', _username
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_USER_QUERY_PARAMS
+
+          perform_request_complex_ignore_404(method, url, params, body, headers, arguments)
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/get_users.rb
+++ b/lib/opensearch/api/actions/security/get_users.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        GET_USERS_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Retrieve all internal users.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#get-users]
+        def get_users(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'internalusers'
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, GET_USERS_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/health.rb
+++ b/lib/opensearch/api/actions/security/health.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        HEALTH_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Checks to see if the Security plugin is up and running.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#health-check]
+        def health(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'health'
+          method  = OpenSearch::API::HTTP_GET
+          params  = Utils.__validate_and_extract_params arguments, HEALTH_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_action_group.rb
+++ b/lib/opensearch/api/actions/security/patch_action_group.rb
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_ACTION_GROUP_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Updates individual attributes of an action group.
+        #
+        # @option arguments [String] :action_group *Required*
+        # @option arguments [Hash] :body
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#patch-action-group]
+        def patch_action_group(arguments = {})
+          raise ArgumentError, "Required argument 'action_group' missing" unless arguments[:action_group]
+
+          arguments = arguments.clone
+          _action_group = arguments.delete(:action_group)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'actiongroups', _action_group
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_ACTION_GROUP_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_action_groups.rb
+++ b/lib/opensearch/api/actions/security/patch_action_groups.rb
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_ACTION_GROUPS_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Creates, updates, or deletes multiple action groups in a single call.
+        #
+        # @option arguments [Hash] :body
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#patch-action-groups]
+        def patch_action_groups(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'actiongroups'
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_ACTION_GROUPS_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_audit_configuration.rb
+++ b/lib/opensearch/api/actions/security/patch_audit_configuration.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_AUDIT_CONFIGURATION_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # A PATCH call is used to update specified fields in the audit configuration.
+        #
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#audit-logs]
+        def patch_audit_configuration(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'audit'
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_AUDIT_CONFIGURATION_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_configuration.rb
+++ b/lib/opensearch/api/actions/security/patch_configuration.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_CONFIGURATION_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # A PATCH call is used to update the existing configuration using the REST API.
+        #
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/2.7/security/access-control/api/#patch-configuration]
+        def patch_configuration(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'securityconfig'
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_CONFIGURATION_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_distinguished_names.rb
+++ b/lib/opensearch/api/actions/security/patch_distinguished_names.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_DISTINGUISHED_NAMES_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Bulk update of distinguished names.
+        #
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#update-all-distinguished-names]
+        def patch_distinguished_names(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'nodesdn'
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_DISTINGUISHED_NAMES_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_role.rb
+++ b/lib/opensearch/api/actions/security/patch_role.rb
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_ROLE_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Updates individual attributes of a role.
+        #
+        # @option arguments [String] :role *Required*
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#patch-role]
+        def patch_role(arguments = {})
+          raise ArgumentError, "Required argument 'role' missing" unless arguments[:role]
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          _role = arguments.delete(:role)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'roles', _role
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_ROLE_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_role_mapping.rb
+++ b/lib/opensearch/api/actions/security/patch_role_mapping.rb
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_ROLE_MAPPING_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Updates individual attributes of a role mapping.
+        #
+        # @option arguments [String] :role *Required*
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#patch-role-mapping]
+        def patch_role_mapping(arguments = {})
+          raise ArgumentError, "Required argument 'role' missing" unless arguments[:role]
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          _role = arguments.delete(:role)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'rolesmapping', _role
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_ROLE_MAPPING_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_role_mappings.rb
+++ b/lib/opensearch/api/actions/security/patch_role_mappings.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_ROLE_MAPPINGS_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Creates or updates multiple role mappings in a single call.
+        #
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#patch-role-mappings]
+        def patch_role_mappings(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'rolesmapping'
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_ROLE_MAPPINGS_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_roles.rb
+++ b/lib/opensearch/api/actions/security/patch_roles.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_ROLES_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Creates, updates, or deletes multiple roles in a single call.
+        #
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#patch-roles]
+        def patch_roles(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'roles'
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_ROLES_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_tenant.rb
+++ b/lib/opensearch/api/actions/security/patch_tenant.rb
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_TENANT_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Add, delete, or modify a single tenant.
+        #
+        # @option arguments [String] :tenant *Required*
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/2.7/security/access-control/api/#patch-tenant]
+        def patch_tenant(arguments = {})
+          raise ArgumentError, "Required argument 'tenant' missing" unless arguments[:tenant]
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          _tenant = arguments.delete(:tenant)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'tenants', _tenant
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_TENANT_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_tenants.rb
+++ b/lib/opensearch/api/actions/security/patch_tenants.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_TENANTS_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Add, delete, or modify multiple tenants in a single call.
+        #
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/2.7/security/access-control/api/#patch-tenants]
+        def patch_tenants(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'tenants'
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_TENANTS_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_user.rb
+++ b/lib/opensearch/api/actions/security/patch_user.rb
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_USER_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Updates individual attributes of an internal user.
+        #
+        # @option arguments [String] :username *Required*
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#patch-user]
+        def patch_user(arguments = {})
+          raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          _username = arguments.delete(:username)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'internalusers', _username
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_USER_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/patch_users.rb
+++ b/lib/opensearch/api/actions/security/patch_users.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        PATCH_USERS_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Creates, updates, or deletes multiple internal users in a single call.
+        #
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#patch-users]
+        def patch_users(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'internalusers'
+          method  = OpenSearch::API::HTTP_PATCH
+          params  = Utils.__validate_and_extract_params arguments, PATCH_USERS_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/reload_http_certificates.rb
+++ b/lib/opensearch/api/actions/security/reload_http_certificates.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        RELOAD_HTTP_CERTIFICATES_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Reload HTTP layer communication certificates.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#reload-http-certificates]
+        def reload_http_certificates(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'ssl', 'http', 'reloadcerts'
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, RELOAD_HTTP_CERTIFICATES_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/reload_transport_certificates.rb
+++ b/lib/opensearch/api/actions/security/reload_transport_certificates.rb
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        RELOAD_TRANSPORT_CERTIFICATES_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Reload transport layer communication certificates.
+        #
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#reload-transport-certificates]
+        def reload_transport_certificates(arguments = {})
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'ssl', 'transport', 'reloadcerts'
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, RELOAD_TRANSPORT_CERTIFICATES_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/update_audit_configuration.rb
+++ b/lib/opensearch/api/actions/security/update_audit_configuration.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        UPDATE_AUDIT_CONFIGURATION_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Updates the audit configuration.
+        #
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#audit-logs]
+        def update_audit_configuration(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'audit', 'config'
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, UPDATE_AUDIT_CONFIGURATION_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/update_configuration.rb
+++ b/lib/opensearch/api/actions/security/update_configuration.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        UPDATE_CONFIGURATION_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Adds or updates the existing configuration using the REST API.
+        #
+        # @option arguments [Hash] :body *Required*
+        #
+        # {API Reference}[https://opensearch.org/docs/2.7/security/access-control/api/#update-configuration]
+        def update_configuration(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          arguments = arguments.clone
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'securityconfig', 'config'
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, UPDATE_CONFIGURATION_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/security/update_distinguished_names.rb
+++ b/lib/opensearch/api/actions/security/update_distinguished_names.rb
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Security
+      module Actions
+        UPDATE_DISTINGUISHED_NAMES_QUERY_PARAMS = Set.new(%i[
+        ]).freeze
+
+        # Adds or updates the specified distinguished names in the cluster’s or node’s allow list.
+        #
+        # @option arguments [String] :cluster_name *Required*
+        # @option arguments [Hash] :body
+        #
+        # {API Reference}[https://opensearch.org/docs/latest/security/access-control/api/#update-distinguished-names]
+        def update_distinguished_names(arguments = {})
+          raise ArgumentError, "Required argument 'cluster_name' missing" unless arguments[:cluster_name]
+
+          arguments = arguments.clone
+          _cluster_name = arguments.delete(:cluster_name)
+
+          headers = arguments.delete(:headers) || {}
+          body    = arguments.delete(:body)
+          url     = Utils.__pathify '_plugins', '_security', 'api', 'nodesdn', _cluster_name
+          method  = OpenSearch::API::HTTP_PUT
+          params  = Utils.__validate_and_extract_params arguments, UPDATE_DISTINGUISHED_NAMES_QUERY_PARAMS
+
+          perform_request(method, url, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/namespace/security.rb
+++ b/lib/opensearch/api/namespace/security.rb
@@ -3,42 +3,25 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-#
-# Modifications Copyright OpenSearch Contributors. See
-# GitHub history for details.
-#
-# Licensed to Elasticsearch B.V. under one or more contributor
-# license agreements. See the NOTICE file distributed with
-# this work for additional information regarding copyright
-# ownership. Elasticsearch B.V. licenses this file to you under
-# the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
 
 module OpenSearch
   module API
     module Security
       module Actions; end
 
-      # Client for the "security" namespace (includes the {Security::Actions} methods)
-      #
+      # Client for the "security" namespace (includes the Security::Actions methods)
       class SecurityClient
         include Security::Actions
-        include Common::Client::Base
         include Common::Client
+        include Common::Client::Base
       end
 
-      # Proxy method for {SecurityClient}, available in the receiving object
-      #
+      # Proxy method for SecurityClient, available in the receiving object
       def security
         @security ||= SecurityClient.new(self)
       end

--- a/spec/opensearch/api/actions/security/change_password_spec.rb
+++ b/spec/opensearch/api/actions/security/change_password_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#change_password' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/account',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.change_password
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.change_password(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/change_password_spec.rb
+++ b/spec/opensearch/api/actions/security/change_password_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#change_password' do
       'PUT',
       '_plugins/_security/api/account',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/create_action_group_spec.rb
+++ b/spec/opensearch/api/actions/security/create_action_group_spec.rb
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#create_action_group' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/actiongroups/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :action_group argument' do
+    expect do
+      client.security.create_action_group
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.create_action_group(
+      action_group: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/create_action_group_spec.rb
+++ b/spec/opensearch/api/actions/security/create_action_group_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#create_action_group' do
       'PUT',
       '_plugins/_security/api/actiongroups/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/create_role_mapping_spec.rb
+++ b/spec/opensearch/api/actions/security/create_role_mapping_spec.rb
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#create_role_mapping' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/rolesmapping/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :role argument' do
+    expect do
+      client.security.create_role_mapping(body: {})
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.create_role_mapping(role: 'songs')
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.create_role_mapping(
+      role: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/create_role_mapping_spec.rb
+++ b/spec/opensearch/api/actions/security/create_role_mapping_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#create_role_mapping' do
       'PUT',
       '_plugins/_security/api/rolesmapping/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/create_role_spec.rb
+++ b/spec/opensearch/api/actions/security/create_role_spec.rb
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#create_role' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/roles/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :role argument' do
+    expect do
+      client.security.create_role(body: {})
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.create_role(role: 'songs')
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.create_role(
+      role: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/create_role_spec.rb
+++ b/spec/opensearch/api/actions/security/create_role_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#create_role' do
       'PUT',
       '_plugins/_security/api/roles/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/create_tenant_spec.rb
+++ b/spec/opensearch/api/actions/security/create_tenant_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#create_tenant' do
       'PUT',
       '_plugins/_security/api/tenants/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/create_tenant_spec.rb
+++ b/spec/opensearch/api/actions/security/create_tenant_spec.rb
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#create_tenant' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/tenants/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :tenant argument' do
+    expect do
+      client.security.create_tenant
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.create_tenant(
+      tenant: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/create_user_spec.rb
+++ b/spec/opensearch/api/actions/security/create_user_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#create_user' do
       'PUT',
       '_plugins/_security/api/internalusers/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/create_user_spec.rb
+++ b/spec/opensearch/api/actions/security/create_user_spec.rb
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#create_user' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/internalusers/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :username argument' do
+    expect do
+      client.security.create_user(body: {})
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.create_user(username: 'songs')
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.create_user(
+      username: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/delete_action_group_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_action_group_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#delete_action_group' do
     [
       'DELETE',
       '_plugins/_security/api/actiongroups/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/delete_action_group_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_action_group_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#delete_action_group' do
+  let(:expected_args) do
+    [
+      'DELETE',
+      '_plugins/_security/api/actiongroups/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :action_group argument' do
+    expect do
+      client.security.delete_action_group
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.delete_action_group(
+      action_group: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/delete_distinguished_names_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_distinguished_names_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#delete_distinguished_names' do
     [
       'DELETE',
       '_plugins/_security/api/nodesdn/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/delete_distinguished_names_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_distinguished_names_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#delete_distinguished_names' do
+  let(:expected_args) do
+    [
+      'DELETE',
+      '_plugins/_security/api/nodesdn/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :cluster_name argument' do
+    expect do
+      client.security.delete_distinguished_names
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.delete_distinguished_names(
+      cluster_name: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/delete_role_mapping_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_role_mapping_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#delete_role_mapping' do
+  let(:expected_args) do
+    [
+      'DELETE',
+      '_plugins/_security/api/rolesmapping/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :role argument' do
+    expect do
+      client.security.delete_role_mapping
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.delete_role_mapping(
+      role: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/delete_role_mapping_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_role_mapping_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#delete_role_mapping' do
     [
       'DELETE',
       '_plugins/_security/api/rolesmapping/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/delete_role_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_role_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#delete_role' do
     [
       'DELETE',
       '_plugins/_security/api/roles/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/delete_role_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_role_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#delete_role' do
+  let(:expected_args) do
+    [
+      'DELETE',
+      '_plugins/_security/api/roles/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :role argument' do
+    expect do
+      client.security.delete_role
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.delete_role(
+      role: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/delete_tenant_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_tenant_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#delete_tenant' do
     [
       'DELETE',
       '_plugins/_security/api/tenants/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/delete_tenant_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_tenant_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#delete_tenant' do
+  let(:expected_args) do
+    [
+      'DELETE',
+      '_plugins/_security/api/tenants/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :tenant argument' do
+    expect do
+      client.security.delete_tenant
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.delete_tenant(
+      tenant: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/delete_user_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_user_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#delete_user' do
     [
       'DELETE',
       '_plugins/_security/api/internalusers/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/delete_user_spec.rb
+++ b/spec/opensearch/api/actions/security/delete_user_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#delete_user' do
+  let(:expected_args) do
+    [
+      'DELETE',
+      '_plugins/_security/api/internalusers/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :username argument' do
+    expect do
+      client.security.delete_user
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.delete_user(
+      username: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/flush_cache_spec.rb
+++ b/spec/opensearch/api/actions/security/flush_cache_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#flush_cache' do
+  let(:expected_args) do
+    [
+      'DELETE',
+      '_plugins/_security/api/cache',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.flush_cache).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/flush_cache_spec.rb
+++ b/spec/opensearch/api/actions/security/flush_cache_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#flush_cache' do
     [
       'DELETE',
       '_plugins/_security/api/cache',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_account_details_spec.rb
+++ b/spec/opensearch/api/actions/security/get_account_details_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_account_details' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/account',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_account_details).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_account_details_spec.rb
+++ b/spec/opensearch/api/actions/security/get_account_details_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_account_details' do
     [
       'GET',
       '_plugins/_security/api/account',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_action_group_spec.rb
+++ b/spec/opensearch/api/actions/security/get_action_group_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_action_group' do
     [
       'GET',
       '_plugins/_security/api/actiongroups/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_action_group_spec.rb
+++ b/spec/opensearch/api/actions/security/get_action_group_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_action_group' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/actiongroups/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :action_group argument' do
+    expect do
+      client.security.get_action_group
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_action_group(
+      action_group: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_action_groups_spec.rb
+++ b/spec/opensearch/api/actions/security/get_action_groups_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_action_groups' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/actiongroups',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_action_groups).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_action_groups_spec.rb
+++ b/spec/opensearch/api/actions/security/get_action_groups_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_action_groups' do
     [
       'GET',
       '_plugins/_security/api/actiongroups',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_audit_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/get_audit_configuration_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_audit_configuration' do
     [
       'GET',
       '_plugins/_security/api/audit',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_audit_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/get_audit_configuration_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_audit_configuration' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/audit',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_audit_configuration).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_certificates_spec.rb
+++ b/spec/opensearch/api/actions/security/get_certificates_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_certificates' do
     [
       'GET',
       '_plugins/_security/api/ssl/certs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_certificates_spec.rb
+++ b/spec/opensearch/api/actions/security/get_certificates_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_certificates' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/ssl/certs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_certificates).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/get_configuration_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_configuration' do
     [
       'GET',
       '_plugins/_security/api/securityconfig',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/get_configuration_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_configuration' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/securityconfig',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_configuration).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_distinguished_names_spec.rb
+++ b/spec/opensearch/api/actions/security/get_distinguished_names_spec.rb
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_distinguished_names' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/nodesdn/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_distinguished_names(
+      cluster_name: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_distinguished_names_spec.rb
+++ b/spec/opensearch/api/actions/security/get_distinguished_names_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_distinguished_names' do
     [
       'GET',
       '_plugins/_security/api/nodesdn/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_role_mapping_spec.rb
+++ b/spec/opensearch/api/actions/security/get_role_mapping_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_role_mapping' do
     [
       'GET',
       '_plugins/_security/api/rolesmapping/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_role_mapping_spec.rb
+++ b/spec/opensearch/api/actions/security/get_role_mapping_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_role_mapping' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/rolesmapping/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :role argument' do
+    expect do
+      client.security.get_role_mapping
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_role_mapping(
+      role: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_role_mappings_spec.rb
+++ b/spec/opensearch/api/actions/security/get_role_mappings_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_role_mappings' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/rolesmapping',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_role_mappings).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_role_mappings_spec.rb
+++ b/spec/opensearch/api/actions/security/get_role_mappings_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_role_mappings' do
     [
       'GET',
       '_plugins/_security/api/rolesmapping',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_role_spec.rb
+++ b/spec/opensearch/api/actions/security/get_role_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_role' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/roles/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :role argument' do
+    expect do
+      client.security.get_role
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_role(
+      role: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_role_spec.rb
+++ b/spec/opensearch/api/actions/security/get_role_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_role' do
     [
       'GET',
       '_plugins/_security/api/roles/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_roles_spec.rb
+++ b/spec/opensearch/api/actions/security/get_roles_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_roles' do
     [
       'GET',
       '_plugins/_security/api/roles',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_roles_spec.rb
+++ b/spec/opensearch/api/actions/security/get_roles_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_roles' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/roles',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_roles).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_tenant_spec.rb
+++ b/spec/opensearch/api/actions/security/get_tenant_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_tenant' do
     [
       'GET',
       '_plugins/_security/api/tenants/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_tenant_spec.rb
+++ b/spec/opensearch/api/actions/security/get_tenant_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_tenant' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/tenants/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :tenant argument' do
+    expect do
+      client.security.get_tenant
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_tenant(
+      tenant: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_tenants_spec.rb
+++ b/spec/opensearch/api/actions/security/get_tenants_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_tenants' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/tenants',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_tenants).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_tenants_spec.rb
+++ b/spec/opensearch/api/actions/security/get_tenants_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_tenants' do
     [
       'GET',
       '_plugins/_security/api/tenants',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_user_spec.rb
+++ b/spec/opensearch/api/actions/security/get_user_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_user' do
     [
       'GET',
       '_plugins/_security/api/internalusers/songs',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_user_spec.rb
+++ b/spec/opensearch/api/actions/security/get_user_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_user' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/internalusers/songs',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :username argument' do
+    expect do
+      client.security.get_user
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_user(
+      username: 'songs'
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/get_users_spec.rb
+++ b/spec/opensearch/api/actions/security/get_users_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#get_users' do
     [
       'GET',
       '_plugins/_security/api/internalusers',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/get_users_spec.rb
+++ b/spec/opensearch/api/actions/security/get_users_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#get_users' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/api/internalusers',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.get_users).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/health_spec.rb
+++ b/spec/opensearch/api/actions/security/health_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#health' do
+  let(:expected_args) do
+    [
+      'GET',
+      '_plugins/_security/health',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.health).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/health_spec.rb
+++ b/spec/opensearch/api/actions/security/health_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#health' do
     [
       'GET',
       '_plugins/_security/health',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/patch_action_group_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_action_group_spec.rb
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_action_group' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/actiongroups/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :action_group argument' do
+    expect do
+      client.security.patch_action_group
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_action_group(
+      action_group: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_action_group_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_action_group_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_action_group' do
       'PATCH',
       '_plugins/_security/api/actiongroups/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_action_groups_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_action_groups_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_action_groups' do
       'PATCH',
       '_plugins/_security/api/actiongroups',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_action_groups_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_action_groups_spec.rb
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_action_groups' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/actiongroups',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_action_groups(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_audit_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_audit_configuration_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_audit_configuration' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/audit',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_audit_configuration
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_audit_configuration(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_audit_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_audit_configuration_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_audit_configuration' do
       'PATCH',
       '_plugins/_security/api/audit',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_configuration_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_configuration' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/securityconfig',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_configuration
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_configuration(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_configuration_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_configuration' do
       'PATCH',
       '_plugins/_security/api/securityconfig',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_distinguished_names_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_distinguished_names_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_distinguished_names' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/nodesdn',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_distinguished_names
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_distinguished_names(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_distinguished_names_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_distinguished_names_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_distinguished_names' do
       'PATCH',
       '_plugins/_security/api/nodesdn',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_role_mapping_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_role_mapping_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_role_mapping' do
       'PATCH',
       '_plugins/_security/api/rolesmapping/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_role_mapping_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_role_mapping_spec.rb
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_role_mapping' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/rolesmapping/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :role argument' do
+    expect do
+      client.security.patch_role_mapping(body: {})
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_role_mapping(role: 'songs')
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_role_mapping(
+      role: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_role_mappings_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_role_mappings_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_role_mappings' do
       'PATCH',
       '_plugins/_security/api/rolesmapping',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_role_mappings_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_role_mappings_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_role_mappings' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/rolesmapping',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_role_mappings
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_role_mappings(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_role_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_role_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_role' do
       'PATCH',
       '_plugins/_security/api/roles/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_role_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_role_spec.rb
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_role' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/roles/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :role argument' do
+    expect do
+      client.security.patch_role(body: {})
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_role(role: 'songs')
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_role(
+      role: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_roles_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_roles_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_roles' do
       'PATCH',
       '_plugins/_security/api/roles',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_roles_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_roles_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_roles' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/roles',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_roles
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_roles(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_tenant_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_tenant_spec.rb
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_tenant' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/tenants/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :tenant argument' do
+    expect do
+      client.security.patch_tenant(body: {})
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_tenant(tenant: 'songs')
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_tenant(
+      tenant: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_tenant_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_tenant_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_tenant' do
       'PATCH',
       '_plugins/_security/api/tenants/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_tenants_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_tenants_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_tenants' do
       'PATCH',
       '_plugins/_security/api/tenants',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_tenants_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_tenants_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_tenants' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/tenants',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_tenants
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_tenants(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_user_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_user_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_user' do
       'PATCH',
       '_plugins/_security/api/internalusers/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/patch_user_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_user_spec.rb
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_user' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/internalusers/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :username argument' do
+    expect do
+      client.security.patch_user(body: {})
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_user(username: 'songs')
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_user(
+      username: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_users_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_users_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#patch_users' do
+  let(:expected_args) do
+    [
+      'PATCH',
+      '_plugins/_security/api/internalusers',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.patch_users
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.patch_users(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/patch_users_spec.rb
+++ b/spec/opensearch/api/actions/security/patch_users_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#patch_users' do
       'PATCH',
       '_plugins/_security/api/internalusers',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/reload_http_certificates_spec.rb
+++ b/spec/opensearch/api/actions/security/reload_http_certificates_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#reload_http_certificates' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/ssl/http/reloadcerts',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.reload_http_certificates).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/reload_http_certificates_spec.rb
+++ b/spec/opensearch/api/actions/security/reload_http_certificates_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#reload_http_certificates' do
     [
       'PUT',
       '_plugins/_security/api/ssl/http/reloadcerts',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/reload_transport_certificates_spec.rb
+++ b/spec/opensearch/api/actions/security/reload_transport_certificates_spec.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#reload_transport_certificates' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/ssl/transport/reloadcerts',
+      nil,
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.reload_transport_certificates).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/reload_transport_certificates_spec.rb
+++ b/spec/opensearch/api/actions/security/reload_transport_certificates_spec.rb
@@ -16,6 +16,7 @@ describe 'client.security#reload_transport_certificates' do
     [
       'PUT',
       '_plugins/_security/api/ssl/transport/reloadcerts',
+      {},
       nil,
       {}
     ]

--- a/spec/opensearch/api/actions/security/update_audit_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/update_audit_configuration_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#update_audit_configuration' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/audit/config',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.update_audit_configuration
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.update_audit_configuration(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/update_audit_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/update_audit_configuration_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#update_audit_configuration' do
       'PUT',
       '_plugins/_security/api/audit/config',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/update_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/update_configuration_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#update_configuration' do
       'PUT',
       '_plugins/_security/api/securityconfig/config',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/update_configuration_spec.rb
+++ b/spec/opensearch/api/actions/security/update_configuration_spec.rb
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#update_configuration' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/securityconfig/config',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect do
+      client.security.update_configuration
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.update_configuration(
+      body: {}
+    )).to eq({})
+  end
+end

--- a/spec/opensearch/api/actions/security/update_distinguished_names_spec.rb
+++ b/spec/opensearch/api/actions/security/update_distinguished_names_spec.rb
@@ -17,6 +17,7 @@ describe 'client.security#update_distinguished_names' do
       'PUT',
       '_plugins/_security/api/nodesdn/songs',
       {},
+      {},
       {}
     ]
   end

--- a/spec/opensearch/api/actions/security/update_distinguished_names_spec.rb
+++ b/spec/opensearch/api/actions/security/update_distinguished_names_spec.rb
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This code was generated from OpenSearch API Spec.
+# Update the code generation logic instead of modifying this file directly.
+
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+describe 'client.security#update_distinguished_names' do
+  let(:expected_args) do
+    [
+      'PUT',
+      '_plugins/_security/api/nodesdn/songs',
+      {},
+      {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include OpenSearch::API }.new
+  end
+
+  it 'requires the :cluster_name argument' do
+    expect do
+      client.security.update_distinguished_names
+    end.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request with all optional params' do
+    expect(client_double.security.update_distinguished_names(
+      cluster_name: 'songs',
+      body: {}
+    )).to eq({})
+  end
+end


### PR DESCRIPTION
- Added all Security API actions as listed on [OpenSearch API Docs](https://opensearch.org/docs/latest/security/access-control/api/) using [api_generator](https://github.com/opensearch-project/opensearch-ruby/tree/main/api_generator).
- Fixed API Generator bugs:
   - Spec failed when an API has no query_params
   - Wrong method names for `perform_request_*_ignore404`

closes https://github.com/opensearch-project/opensearch-ruby/issues/171

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
