### PR TITLE
Renamed `build.sh` to `build_gem.sh`

### DIFF
--- a/.github/build_gem.sh
+++ b/.github/build_gem.sh
@@ -8,7 +8,7 @@
 # Modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
 
-#set -e
+set -e
 GIT_ROOT=$(git rev-parse --show-toplevel)
 
 rm -rf dist && mkdir dist


### PR DESCRIPTION
The new name is clearer and matches the name used in `release_drafter` workflow
(forgot to do this after updating the workflow and the script to make it work with single-gem repo)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
