### PR TITLE
Provide cert path to publishing library

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -10,5 +10,6 @@ standardReleasePipelineWithGenericTrigger(
     publishRelease: true) {
         publishToRubyGems(
             publicCertPath: "${WORKSPACE}/.github/opensearch-rubygems.pem",
-            apiKeyCredentialId: 'jenkins-opensearch-ruby-api-key')
+            apiKeyCredentialId: 'jenkins-opensearch-ruby-api-key'
+            )
     }

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -8,5 +8,7 @@ standardReleasePipelineWithGenericTrigger(
     causeString: 'A tag was cut on opensearch-project/opensearch-ruby repository causing this workflow to run',
     downloadReleaseAsset: true,
     publishRelease: true) {
-        publishToRubyGems(apiKeyCredentialId: 'jenkins-opensearch-ruby-api-key')
+        publishToRubyGems(
+            publicCertPath: "${WORKSPACE}/.github/opensearch-rubygems.pem",
+            apiKeyCredentialId: 'jenkins-opensearch-ruby-api-key')
     }


### PR DESCRIPTION
### Description
Looks like cert path changed from default `certs/` folder to .github.
Accommodating the same here in jenkins library.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
