### PR TITLE
Update the cert path to the publishing library in the release Jenkins job

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -9,7 +9,7 @@ standardReleasePipelineWithGenericTrigger(
     downloadReleaseAsset: true,
     publishRelease: true) {
         publishToRubyGems(
-            publicCertPath: "${WORKSPACE}/.github/opensearch-rubygems.pem",
+            publicCertPath: ".github/opensearch-rubygems.pem",
             apiKeyCredentialId: 'jenkins-opensearch-ruby-api-key'
             )
     }


### PR DESCRIPTION
### Description
Provide the right path to certificate in the release Jenkins Job
### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
