### PR TITLE
Missing require

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -43,7 +43,7 @@ jobs:
           ruby -v
           bundle install
       - name: Run All Tests
-        run: bundle exec rake test:all
+        run: rake test:all
 
   test-opensearch-security:
     env:
@@ -77,4 +77,4 @@ jobs:
           ruby -v
           bundle install
       - name: opensearch-ruby
-        run: bundle exec rake test:client:security
+        run: rake test:client:security

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           ruby -v
           bundle install
       - name: Run All Tests
-        run: bundle exec rake test:all
+        run: rake test:all
 
   test-opensearch-faraday-1:
     env:
@@ -78,7 +78,7 @@ jobs:
           ruby -v
           bundle install
       - name: Test Faraday on Transport Layer
-        run: bundle exec rake test:transport:all
+        run: rake test:transport:all
 
   test-opensearch-security:
     env:
@@ -112,4 +112,4 @@ jobs:
           ruby -v
           bundle install
       - name: Test Client Security
-        run: bundle exec rake test:client:security
+        run: rake test:client:security

--- a/.github/workflows/test-unreleased.yml
+++ b/.github/workflows/test-unreleased.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: opensearch-ruby
         working-directory: ruby-client
-        run: bundle exec rake test:integration
+        run: rake test:integration
 
       - name: Save server logs
         if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed missing version require [#205](https://github.com/opensearch-project/opensearch-ruby/issues/205) ([#206](https://github.com/opensearch-project/opensearch-ruby/pull/206))
 ### Security
 
 ## [3.0.0]

--- a/lib/opensearch.rb
+++ b/lib/opensearch.rb
@@ -24,6 +24,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'opensearch/version'
 require 'opensearch/transport'
 require 'opensearch/api'
 


### PR DESCRIPTION
### Description
Add a missing require to `opensearch/version`.

CI didn't catch this because `bundle exec rake` loads the gemspec file which requires the version on it's own. CI has no need for `bundle exec` since there will only ever be the exact gems installed so I have changed workflow to call rake on it's own.

### Issues Resolved
#205

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
