### PR TITLE
Don't modify the response if the body is frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed the response body being force-encoded when it was already in UTF-8 ([#212](https://github.com/opensearch-project/opensearch-ruby/issues/212))
 ### Security
 
 ## [3.0.1]

--- a/lib/opensearch/transport/transport/response.rb
+++ b/lib/opensearch/transport/transport/response.rb
@@ -39,7 +39,7 @@ module OpenSearch
           @status = status
           @body = body
           @headers = headers
-          @body = body.force_encoding('UTF-8') if body.respond_to?(:force_encoding)
+          @body = body.force_encoding('UTF-8') if body.respond_to?(:force_encoding) && body.encoding != Encoding::UTF_8
         end
       end
     end

--- a/test/transport/unit/response_test.rb
+++ b/test/transport/unit/response_test.rb
@@ -28,8 +28,7 @@ require_relative '../test_helper'
 
 class OpenSearch::Transport::Transport::ResponseTest < Minitest::Test
   context "Response" do
-
-    should "force-encode the body into UTF" do
+    should "force-encode the body into UTF-8" do
       body = "Hello Encoding!".encode(Encoding::ISO_8859_1)
       assert_equal 'ISO-8859-1', body.encoding.name
 
@@ -37,5 +36,11 @@ class OpenSearch::Transport::Transport::ResponseTest < Minitest::Test
       assert_equal 'UTF-8', response.body.encoding.name
     end
 
+    should "not force-encode the body if it is already encoded as UTF-8" do
+      body = "Hello Frozen!".freeze
+      response = OpenSearch::Transport::Transport::Response.new 200, body
+
+      assert_equal body, response.body
+    end
   end
 end


### PR DESCRIPTION
Fixes an incompatibility with webmock since 3.19, where it started to freeze the response body for performance reasons

### Description
https://github.com/bblimke/webmock/pull/1033
https://github.com/bblimke/webmock/blob/v3.19.0/CHANGELOG.md#3190

When using code like the following, the response object tries to modify a frozen string:
```rb
def test_cluster_health_called
  stub_request(:get, "http://opensearch/_cluster/health")

  method_that_calls_out_to_cluster_health
  # => FrozenError: can't modify frozen String: ""
end
```

This started happening since webmock version 3.19 because they applied the frozen string literal comment to their codebase. When not specifying a response body with `to_return(body: something)` the string will come from webmock itself and be frozen.

This changes the response to not modify the body when the string is frozen, avoiding this error.

On a side-node, this also fixes webmock when the test files itself are using the frozen string literal comment, like so:

```rb
# frozen_string_literal: true

def test_cluster_health_called
  stub_request(:get, "http://opensearch/_cluster/health").to_return(body: "{}")

  method_that_calls_out_to_cluster_health
  # => FrozenError: can't modify frozen String: "{}"
end
```

Additional context:
https://github.com/elastic/elastic-transport-ruby/issues/63
https://github.com/elastic/elastic-transport-ruby/pull/64

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
