### PR TITLE
Remove reference to default credentials

### DIFF
--- a/.github/actions/opensearch/run.sh
+++ b/.github/actions/opensearch/run.sh
@@ -59,11 +59,15 @@ else
   # Starting in 2.12.0, security demo configuration script requires an initial admin password which is set to 
   # myStrongPassword123!
   OPENSEARCH_REQUIRED_VERSION="2.12.0"
-  COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $CLUSTER_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
-  if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
-    CREDENTIAL="admin:admin"
-  else
+  if [ "$CLUSTER_VERSION" == "latest" ]; then
     CREDENTIAL="admin:myStrongPassword123!"
+  else
+    COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $CLUSTER_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+    if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
+      CREDENTIAL="admin:admin"
+    else
+      CREDENTIAL="admin:myStrongPassword123!"
+    fi
   fi
   docker run \
     --network cluster \

--- a/.github/actions/opensearch/run.sh
+++ b/.github/actions/opensearch/run.sh
@@ -59,7 +59,7 @@ else
   # Starting in 2.12.0, security demo configuration script requires an initial admin password which is set to 
   # myStrongPassword123!
   OPENSEARCH_REQUIRED_VERSION="2.12.0"
-  COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+  COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $CLUSTER_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
   if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
     CREDENTIAL="admin:admin"
   else

--- a/.github/actions/opensearch/run.sh
+++ b/.github/actions/opensearch/run.sh
@@ -32,6 +32,7 @@ do
     --env "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
     --env "http.port=${port}" \
     --env "action.destructive_requires_name=false" \
+    --env "OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!" \
     --env "plugins.security.disabled=${DISABLE_SECURITY}" \
     --ulimit nofile=65536:65536 \
     --ulimit memlock=-1:-1 \
@@ -66,7 +67,7 @@ else
     --show-error \
     --silent \
     --insecure \
-    https://admin:admin@os1:$PORT
+    https://admin:myStrongPassword123!@os1:$PORT
 fi
 
 sleep 10

--- a/.github/actions/opensearch/run.sh
+++ b/.github/actions/opensearch/run.sh
@@ -56,18 +56,34 @@ if [[ $DISABLE_SECURITY = true ]]; then
     --silent \
     http://os1:$PORT
 else
-  docker run \
-    --network cluster \
-    --rm \
-    appropriate/curl \
-    --max-time 120 \
-    --retry 120 \
-    --retry-delay 1 \
-    --retry-connrefused \
-    --show-error \
-    --silent \
-    --insecure \
-    https://admin:myStrongPassword123!@os1:$PORT
+  if [[ $CLUSTER_VERSION = 'latest' ]]; then
+    # Since 2.12.0, security demo configuration requires an initial admin password, which is set to 
+    # myStrongPassword123!
+    docker run \
+      --network cluster \
+      --rm \
+      appropriate/curl \
+      --max-time 120 \
+      --retry 120 \
+      --retry-delay 1 \
+      --retry-connrefused \
+      --show-error \
+      --silent \
+      --insecure \
+      https://admin:myStrongPassword123!@os1:$PORT
+  else
+    docker run \
+      --network cluster \
+      --rm \
+      appropriate/curl \
+      --max-time 120 \
+      --retry 120 \
+      --retry-delay 1 \
+      --retry-connrefused \
+      --show-error \
+      --silent \
+      --insecure \
+      https://admin:admin!@os1:$PORT
 fi
 
 sleep 10

--- a/.github/actions/opensearch/run.sh
+++ b/.github/actions/opensearch/run.sh
@@ -56,35 +56,27 @@ if [[ $DISABLE_SECURITY = true ]]; then
     --silent \
     http://os1:$PORT
 else
-  if [[ $CLUSTER_VERSION = 'latest' ]]; then
-    # Since 2.12.0, security demo configuration requires an initial admin password, which is set to 
-    # myStrongPassword123!
-    docker run \
-      --network cluster \
-      --rm \
-      appropriate/curl \
-      --max-time 120 \
-      --retry 120 \
-      --retry-delay 1 \
-      --retry-connrefused \
-      --show-error \
-      --silent \
-      --insecure \
-      https://admin:myStrongPassword123!@os1:$PORT
+  # Starting in 2.12.0, security demo configuration script requires an initial admin password which is set to 
+  # myStrongPassword123!
+  OPENSEARCH_REQUIRED_VERSION="2.12.0"
+  COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+  if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
+    CREDENTIAL="admin:admin"
   else
-    docker run \
-      --network cluster \
-      --rm \
-      appropriate/curl \
-      --max-time 120 \
-      --retry 120 \
-      --retry-delay 1 \
-      --retry-connrefused \
-      --show-error \
-      --silent \
-      --insecure \
-      https://admin:admin!@os1:$PORT
+    CREDENTIAL="admin:myStrongPassword123!"
   fi
+  docker run \
+    --network cluster \
+    --rm \
+    appropriate/curl \
+    --max-time 120 \
+    --retry 120 \
+    --retry-delay 1 \
+    --retry-connrefused \
+    --show-error \
+    --silent \
+    --insecure \
+    https://$CREDENTIAL@os1:$PORT
 fi
 
 sleep 10

--- a/.github/actions/opensearch/run.sh
+++ b/.github/actions/opensearch/run.sh
@@ -84,6 +84,7 @@ else
       --silent \
       --insecure \
       https://admin:admin!@os1:$PORT
+  fi
 fi
 
 sleep 10

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -47,7 +47,7 @@ jobs:
 
   test-opensearch-security:
     env:
-      TEST_OPENSEARCH_SERVER: https://admin:myStrongPassword123!@localhost:9200
+      TEST_OPENSEARCH_SERVER: https://admin:admin@localhost:9200
       PORT: 9200
     strategy:
       fail-fast: false

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -47,7 +47,7 @@ jobs:
 
   test-opensearch-security:
     env:
-      TEST_OPENSEARCH_SERVER: https://admin:admin@localhost:9200
+      TEST_OPENSEARCH_SERVER: https://admin:myStrongPassword123!@localhost:9200
       PORT: 9200
     strategy:
       fail-fast: false

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.0.8
+        uses: lycheeverse/lychee-action@v1.9.0
         with:
           args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "https://github.com/\[your*" --exclude "https://localhost:9200" --exclude "http://localhost:9200" --exclude "git://github.com/opensearch-project/*" --exclude "file:///github/workspace/*" --exclude ".*api.server.org:4430/search" --exclude ".*example.com:9200" --exclude ".*myhost:8080" --exclude ".*localhost:9200/" --exclude-mail
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
 
   test-opensearch-security:
     env:
-      TEST_OPENSEARCH_SERVER: https://admin:admin@localhost:9200
+      TEST_OPENSEARCH_SERVER: https://admin:myStrongPassword123!@localhost:9200
       PORT: 9200
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Pass in an initial admin password, required by security after 2.12.0 release ([#217](https://github.com/opensearch-project/opensearch-ruby/issues/217))
 ### Changed
 ### Deprecated
 ### Removed


### PR DESCRIPTION
### Description
Removes references to default admin credentials, which were removed in 2.12

### Issues Resolved
Closes #222 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
