### PR TITLE
Add base64 to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Added base64 gem to gemspec (#218)[https://github.com/opensearch-project/opensearch-ruby/pull/218]
 ### Changed
 ### Deprecated
 ### Removed

--- a/opensearch-ruby.gemspec
+++ b/opensearch-ruby.gemspec
@@ -66,4 +66,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '>= 1.0', '< 3'
   s.add_dependency 'multi_json', '>= 1.0'
+  s.add_dependency 'base64'
 end

--- a/opensearch-ruby.gemspec
+++ b/opensearch-ruby.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
+  s.add_dependency 'base64'
   s.add_dependency 'faraday', '>= 1.0', '< 3'
   s.add_dependency 'multi_json', '>= 1.0'
-  s.add_dependency 'base64'
 end


### PR DESCRIPTION
### Description
* Add base64 to gemspec, which is no longer the default gem from Ruby 3.4.
  * `opensearch-ruby` uses base64 gem in client.rb
```
❯ git grep "require 'base64'"
lib/opensearch/transport/client.rb:27:require 'base64'
```

### References
* similar support in rails/rails: https://github.com/rails/rails/pull/48907
* bugs.ruby-lang: https://bugs.ruby-lang.org/issues/19776
* ruby/ruby: https://github.com/ruby/ruby/pull/8126


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
