### PR TITLE
Remove a todo in the testing workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,7 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
       - uses: ./.github/actions/opensearch
         with:
-          # TODO: change cluster-version back to `latest` after OS 2.9.1 or later is released
-          cluster-version: "2.8.0"
+          cluster-version: latest
           disable-security: true
       - uses: ruby/setup-ruby@v1
         with:
@@ -65,8 +64,7 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
       - uses: ./.github/actions/opensearch
         with:
-          # TODO: change cluster-version back to `latest` after OS 2.9.1 or later is released
-          cluster-version: "2.8.0"
+          cluster-version: latest
           disable-security: true
       - uses: ruby/setup-ruby@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Switch back to the latest OpenSearch version when testing in CI ([#219](https://github.com/opensearch-project/opensearch-ruby/pull/219))
 ### Security
 
 ## [3.1.0]


### PR DESCRIPTION
Added with https://github.com/opensearch-project/opensearch-ruby/pull/178, should now be good to switch back.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
