### PR TITLE
Test against ruby 3.3

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -35,7 +35,7 @@ jobs:
           disable-security: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
       - name: Build and test with Rake
         run: |
           sudo apt-get update
@@ -68,7 +68,7 @@ jobs:
           disable-security: false
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
       - name: Build and test with Rake
         run: |
           sudo apt-get update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
+        ruby: [ 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.3 ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby-9.3 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-unreleased.yml
+++ b/.github/workflows/test-unreleased.yml
@@ -19,10 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { ruby_version: '3.2', opensearch_ref: '1.x' }
-          - { ruby_version: '3.2', opensearch_ref: '2.x' }
-          - { ruby_version: '3.2', opensearch_ref: '2.0' }
-          - { ruby_version: '3.2', opensearch_ref: 'main' }
+          - { ruby_version: '3.3', opensearch_ref: '1.x' }
+          - { ruby_version: '3.3', opensearch_ref: '2.x' }
+          - { ruby_version: '3.3', opensearch_ref: '2.0' }
+          - { ruby_version: '3.3', opensearch_ref: 'main' }
 
     steps:
       - uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Added base64 gem to gemspec (#218)[https://github.com/opensearch-project/opensearch-ruby/pull/218]
+- Added support for Ruby 3.3 ([#220](https://github.com/opensearch-project/opensearch-ruby/pull/220))
 ### Changed
 ### Deprecated
 ### Removed


### PR DESCRIPTION
### Description
Add the newly released ruby version to CI.

Question: JRuby is  being tested against 9.3 but 9.4 has been released [a while ago](https://www.jruby.org/2022/11/23/jruby-9-4-0-0.html). Should I also change this? If so, I'll do that after this PR has been merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
