### PR TITLE
Remove dependency on the base64 gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- Added base64 gem to gemspec (#218)[https://github.com/opensearch-project/opensearch-ruby/pull/218]
 - Added support for Ruby 3.3 ([#220](https://github.com/opensearch-project/opensearch-ruby/pull/220))
 ### Changed
 ### Deprecated
 ### Removed
+- Removed dependency on the base64 gem ([#221](https://github.com/opensearch-project/opensearch-ruby/pull/221))
 ### Fixed
 - Switch back to the latest OpenSearch version when testing in CI ([#219](https://github.com/opensearch-project/opensearch-ruby/pull/219))
 ### Security

--- a/lib/opensearch/transport/client.rb
+++ b/lib/opensearch/transport/client.rb
@@ -24,8 +24,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'base64'
-
 module OpenSearch
   module Transport
     # Handles communication with an OpenSearch cluster.
@@ -225,7 +223,8 @@ module OpenSearch
         return unless arguments[:cloud_id] && !arguments[:cloud_id].empty?
 
         name = arguments[:cloud_id].split(':')[0]
-        cloud_url, opensearch_instance = Base64.decode64(arguments[:cloud_id].gsub("#{name}:", '')).split('$')
+        base64_decoded = arguments[:cloud_id].gsub("#{name}:", '').unpack1('m')
+        cloud_url, opensearch_instance = base64_decoded.split('$')
 
         if cloud_url.include?(':')
           url, port = cloud_url.split(':')
@@ -355,7 +354,8 @@ module OpenSearch
       # Encode credentials for the Authorization Header
       # Credentials is the base64 encoding of id and api_key joined by a colon
       def __encode(api_key)
-        Base64.strict_encode64([api_key[:id], api_key[:api_key]].join(':'))
+        joined = [api_key[:id], api_key[:api_key]].join(':')
+        [joined].pack('m0')
       end
     end
   end

--- a/opensearch-ruby.gemspec
+++ b/opensearch-ruby.gemspec
@@ -64,7 +64,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency 'base64'
   s.add_dependency 'faraday', '>= 1.0', '< 3'
   s.add_dependency 'multi_json', '>= 1.0'
 end

--- a/spec/opensearch/transport/client_spec.rb
+++ b/spec/opensearch/transport/client_spec.rb
@@ -98,7 +98,8 @@ describe OpenSearch::Transport::Client do
     end
 
     it 'Adds the ApiKey header to the connection' do
-      expect(authorization_header).to eq("ApiKey #{Base64.strict_encode64('my_id:my_api_key')}")
+      strict_base64_encoded = ["my_id:my_api_key"].pack("m0")
+      expect(authorization_header).to eq("ApiKey #{strict_base64_encoded}")
     end
   end
 


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/opensearch-ruby/pull/218 removed a warning in ruby 3.3 because of the base64 dependency. Since it's just a wrapper around the pack/unpack methods it's trivial to replace.

* https://github.com/rack/rack/pull/2110
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/newrelic/newrelic-ruby-agent/pull/2378
* https://github.com/lostisland/faraday/pull/1541



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
