### PR TITLE
add search_pipeline query parameter to search api

### DIFF
--- a/lib/opensearch/api/actions/search.rb
+++ b/lib/opensearch/api/actions/search.rb
@@ -153,6 +153,7 @@ module OpenSearch
         pre_filter_shard_size
         rest_total_hits_as_int
         min_compatible_shard_node
+        search_pipeline
       ].freeze)
     end
   end


### PR DESCRIPTION
### Description
This change allow usage of search pipeline (e.g https://opensearch.org/docs/latest/search-plugins/search-pipelines/rename-field-processor/) in search api.

Related to #224 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
