### PR TITLE
Don't emit Ruby warnings when requiring `opensearch-dsl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Don't emit Ruby warnings when requiring `opensearch-dsl` ([#231](https://github.com/opensearch-project/opensearch-ruby/issues/231))
 ### Security
 
 ## [3.2.0]

--- a/lib/opensearch/dsl/search/options.rb
+++ b/lib/opensearch/dsl/search/options.rb
@@ -55,10 +55,10 @@ module OpenSearch
           define_method name do |*args|
             @hash[name] = args.pop
           end
+        end
 
-          define_method name.to_s.gsub(/^_(.*)/, '\1') do |*args|
-            @hash[name] = args.pop
-          end
+        def source(*args)
+          @hash[:_source] = args.pop
         end
 
         # Returns true when there are no search options defined

--- a/lib/opensearch/dsl/search/queries/match.rb
+++ b/lib/opensearch/dsl/search/queries/match.rb
@@ -59,7 +59,6 @@ module OpenSearch
           option_method :lenient
           option_method :zero_terms_query
           option_method :cutoff_frequency
-          option_method :max_expansions
         end
       end
     end


### PR DESCRIPTION
### Description

The removed `define_method` in `options.rb` just ensured that you are able to use `source` and `_source`, that's all this does. The other entries where this isn't a problem are simply overwritten, as you can see from the warnings. Just switch to handwriting this one special case.

The second change removes a `option_method :max_expansions` from `match.rb`. This previously appeared twice in the list and also caused a warning.

```
$ RUBYOPT=-w bundle exec irb
irb(main):001> require "opensearch-dsl"
opensearch-ruby/lib/opensearch/dsl/search/options.rb:59: warning: method redefined; discarding old fields
opensearch-ruby/lib/opensearch/dsl/search/options.rb:55: warning: previous definition of fields was here
opensearch-ruby/lib/opensearch/dsl/search/options.rb:59: warning: method redefined; discarding old script_fields
opensearch-ruby/lib/opensearch/dsl/search/options.rb:55: warning: previous definition of script_fields was here
opensearch-ruby/lib/opensearch/dsl/search/options.rb:59: warning: method redefined; discarding old fielddata_fields
opensearch-ruby/lib/opensearch/dsl/search/options.rb:55: warning: previous definition of fielddata_fields was here
opensearch-ruby/lib/opensearch/dsl/search/options.rb:59: warning: method redefined; discarding old rescore
opensearch-ruby/lib/opensearch/dsl/search/options.rb:55: warning: previous definition of rescore was here
opensearch-ruby/lib/opensearch/dsl/search/options.rb:59: warning: method redefined; discarding old explain
opensearch-ruby/lib/opensearch/dsl/search/options.rb:55: warning: previous definition of explain was here
opensearch-ruby/lib/opensearch/dsl/search/options.rb:59: warning: method redefined; discarding old version
opensearch-ruby/lib/opensearch/dsl/search/options.rb:55: warning: previous definition of version was here
opensearch-ruby/lib/opensearch/dsl/search/options.rb:59: warning: method redefined; discarding old indices_boost
opensearch-ruby/lib/opensearch/dsl/search/options.rb:55: warning: previous definition of indices_boost was here
opensearch-ruby/lib/opensearch/dsl/search/options.rb:59: warning: method redefined; discarding old track_scores
opensearch-ruby/lib/opensearch/dsl/search/options.rb:55: warning: previous definition of track_scores was here
opensearch-ruby/lib/opensearch/dsl/search/options.rb:59: warning: method redefined; discarding old min_score
opensearch-ruby/lib/opensearch/dsl/search/options.rb:55: warning: previous definition of min_score was here
opensearch-ruby/lib/opensearch/dsl/search/options.rb:59: warning: method redefined; discarding old track_total_hits
opensearch-ruby/lib/opensearch/dsl/search/options.rb:55: warning: previous definition of track_total_hits was here
opensearch-ruby/lib/opensearch/dsl/search/base_component.rb:75: warning: method redefined; discarding old max_expansions
opensearch-ruby/lib/opensearch/dsl/search/base_component.rb:75: warning: previous definition of max_expansions was here
=> true
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
