### PR TITLE
Fix release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Don't emit Ruby warnings when requiring `opensearch-dsl` ([#231](https://github.com/opensearch-project/opensearch-ruby/issues/231))
+- Fix release workflow ([#232](https://github.com/opensearch-project/opensearch-ruby/issues/232))
 ### Security
 
 ## [3.2.0]

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -10,6 +10,7 @@ standardReleasePipelineWithGenericTrigger(
     publishRelease: true) {
         publishToRubyGems(
             publicCertPath: ".github/opensearch-rubygems.pem",
-            apiKeyCredentialId: 'jenkins-opensearch-ruby-api-key'
+            apiKeyCredentialId: 'jenkins-opensearch-ruby-api-key',
+            rubyVersion: "3.0.6"
             )
     }


### PR DESCRIPTION
### Description
As per https://github.com/opensearch-project/opensearch-build-libraries/blob/6d35e942e98e1acddd88633a2aa1bbe39ab5e002/vars/publishToRubyGems.groovy#L23 this is a supported config option.
The build failure is visible here: https://build.ci.opensearch.org/blue/organizations/jenkins/opensearch-ruby-gems-release/detail/opensearch-ruby-gems-release/31/pipeline

### Issues Resolved
#232. I have manually confirmed that gem install with ruby 3.0 works. There are other warnings in the output relating to gem signing but I'm thinking that these are just errors happening down the road because of the the ruby version incompatibility.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
