### PR TITLE
Switch ruby version to 3.1.2 on release pipeline

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@5.7.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.4.4', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -11,6 +11,6 @@ standardReleasePipelineWithGenericTrigger(
         publishToRubyGems(
             publicCertPath: ".github/opensearch-rubygems.pem",
             apiKeyCredentialId: 'jenkins-opensearch-ruby-api-key',
-            rubyVersion: "3.0.6"
+            rubyVersion: "3.1.2"
             )
     }


### PR DESCRIPTION
### Description
Switch ruby version to 3.1.2 on release pipeline. There is no need to switch the docker image as, it is already pointing to most recent one. 

### Issues Resolved
closes https://github.com/opensearch-project/opensearch-build/issues/4624

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
