### PR TITLE
Bump build-lib version to consume ruby cert fixes

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@6.4.4', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.4.5', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Bump build-lib version to consume ruby cert fixes

See the related changes in this version: https://github.com/opensearch-project/opensearch-build-libraries/releases/tag/6.4.5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
