### PR TITLE
Add script_score to query DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Added `script_score` to Query DSL ([#254](https://github.com/opensearch-project/opensearch-ruby/pull/254))
 ### Changed
 ### Deprecated
 ### Removed

--- a/lib/opensearch/dsl/search/queries/script_score.rb
+++ b/lib/opensearch/dsl/search/queries/script_score.rb
@@ -28,7 +28,7 @@ module OpenSearch
   module DSL
     module Search
       module Queries
-        # A query which wraps another query and returns a customize score for matching documents
+        # A query which wraps another query and returns a customized score for matching documents
         #
         # @example
         #
@@ -39,7 +39,7 @@ module OpenSearch
         #             match content: 'Twitter'
         #           end
         #
-        #           script source: "_score * params['multiplier']"
+        #           script source: "_score * params['multiplier']",
         #                  params: { multiplier: 2.0 }
         #         end
         #       end

--- a/lib/opensearch/dsl/search/queries/script_score.rb
+++ b/lib/opensearch/dsl/search/queries/script_score.rb
@@ -38,9 +38,9 @@ module OpenSearch
         #           query do
         #             match content: 'Twitter'
         #           end
-        #           script {
-        #             source: "_score * doc['multiplier'].value"
-        #           }
+        #
+        #           script source: "_score * params['multiplier']"
+        #                  params: { multiplier: 2.0 }
         #         end
         #       end
         #     end

--- a/lib/opensearch/dsl/search/queries/script_score.rb
+++ b/lib/opensearch/dsl/search/queries/script_score.rb
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 module OpenSearch
   module DSL
     module Search

--- a/lib/opensearch/dsl/search/queries/script_score.rb
+++ b/lib/opensearch/dsl/search/queries/script_score.rb
@@ -1,29 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-#
-# The OpenSearch Contributors require contributions made to
-# this file be licensed under the Apache-2.0 license or a
-# compatible open source license.
-#
-# Modifications Copyright OpenSearch Contributors. See
-# GitHub history for details.
-#
-# Licensed to Elasticsearch B.V. under one or more contributor
-# license agreements. See the NOTICE file distributed with
-# this work for additional information regarding copyright
-# ownership. Elasticsearch B.V. licenses this file to you under
-# the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 module OpenSearch
   module DSL
     module Search

--- a/lib/opensearch/dsl/search/queries/script_score.rb
+++ b/lib/opensearch/dsl/search/queries/script_score.rb
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+#
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module OpenSearch
+  module DSL
+    module Search
+      module Queries
+        # A query which wraps another query and returns a customize score for matching documents
+        #
+        # @example
+        #
+        #     search do
+        #       query do
+        #         script_score do
+        #           query do
+        #             match content: 'Twitter'
+        #           end
+        #           script {
+        #             source: "_score * doc['multiplier'].value"
+        #           }
+        #         end
+        #       end
+        #     end
+        #
+        # @see https://opensearch.org/docs/latest/query-dsl/specialized/script-score/
+        #
+        class ScriptScore
+          include BaseComponent
+
+          option_method :script
+          option_method :min_score
+          option_method :boost
+
+          # DSL method for building the `query` part of the query definition
+          #
+          # @return [self]
+          #
+          def query(*args, &block)
+            @query = block ? @query = Query.new(*args, &block) : args.first
+            self
+          end
+
+          # Converts the query definition to a Hash
+          #
+          # @return [Hash]
+          #
+          def to_hash
+            hash = super
+            if @query
+              _query = @query.respond_to?(:to_hash) ? @query.to_hash : @query
+              hash[name].update(query: _query)
+            end
+            hash
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/opensearch/dsl/search/queries/script_score_spec.rb
+++ b/spec/opensearch/dsl/search/queries/script_score_spec.rb
@@ -1,29 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-#
-# The OpenSearch Contributors require contributions made to
-# this file be licensed under the Apache-2.0 license or a
-# compatible open source license.
-#
-# Modifications Copyright OpenSearch Contributors. See
-# GitHub history for details.
-#
-# Licensed to Elasticsearch B.V. under one or more contributor
-# license agreements. See the NOTICE file distributed with
-# this work for additional information regarding copyright
-# ownership. Elasticsearch B.V. licenses this file to you under
-# the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 require_relative '../../../../spec_helper'
 
 describe OpenSearch::DSL::Search::Queries::ScriptScore do

--- a/spec/opensearch/dsl/search/queries/script_score_spec.rb
+++ b/spec/opensearch/dsl/search/queries/script_score_spec.rb
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+#
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative '../../../../spec_helper'
+
+describe OpenSearch::DSL::Search::Queries::ScriptScore do
+  describe '#to_hash' do
+    let(:search) do
+      described_class.new
+    end
+
+    it 'can be converted to a hash' do
+      expect(search.to_hash).to eq(script_score: {})
+    end
+  end
+
+  context 'when options methods are called' do
+    let(:search) do
+      described_class.new
+    end
+
+    describe '#query' do
+      before do
+        search.query('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:script_score][:query]).to eq('bar')
+      end
+    end
+
+    describe '#boost' do
+      before do
+        search.boost('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:script_score][:boost]).to eq('bar')
+      end
+    end
+
+    describe '#script' do
+      before do
+        search.script('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:script_score][:script]).to eq('bar')
+      end
+    end
+
+    describe '#min_score' do
+      before do
+        search.min_score('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:script_score][:min_score]).to eq('bar')
+      end
+    end
+  end
+
+  describe '#initialize' do
+    context 'when a block is provided' do
+      let(:search) do
+        described_class.new do
+          query do
+            term foo: 'bar'
+          end
+
+          script source: 'foo',
+                 params: { foo: 'bar' }
+          boost 'bar'
+          min_score 'bar'
+        end
+      end
+
+      it 'executes the block' do
+        expect(search.to_hash[:script_score][:query][:term][:foo]).to eq('bar')
+        expect(search.to_hash[:script_score][:script][:source]).to eq('foo')
+        expect(search.to_hash[:script_score][:script][:params]).to eq(foo: 'bar')
+        expect(search.to_hash[:script_score][:boost]).to eq('bar')
+        expect(search.to_hash[:script_score][:min_score]).to eq('bar')
+      end
+    end
+  end
+end

--- a/spec/opensearch/dsl/search/queries/script_score_spec.rb
+++ b/spec/opensearch/dsl/search/queries/script_score_spec.rb
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 require_relative '../../../../spec_helper'
 
 describe OpenSearch::DSL::Search::Queries::ScriptScore do


### PR DESCRIPTION
### Description
Script Score query was added to OpenSearch 2.9 and current query DSL does not support it.
This PR add script_score to query DSL.

### Issues Resolved
https://github.com/opensearch-project/opensearch-ruby/issues/253

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).