### PR TITLE
Test against Ruby 3.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: '3.0'
       - run: |
           sudo apt-get update
           sudo apt-get install libcurl4-openssl-dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', 3.3, jruby-9.4 ]
+        ruby: [ '3.0', 3.1, 3.2, 3.3, jruby-9.4 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', 3.1, 3.2, 3.3, jruby-9.4 ]
+        ruby: [ '3.0', 3.1, 3.2, 3.3, 3.4, jruby-9.4 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', 3.3, jruby-9.4 ]
+        ruby: [ '3.0', 3.4, jruby-9.4 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', 3.3, jruby-9.4 ]
+        ruby: [ '3.0', 3.4, jruby-9.4 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 3.0, 3.3, jruby-9.4 ]
+        ruby: [ '3.0', 3.3, jruby-9.4 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 3.0, 3.3, jruby-9.4 ]
+        ruby: [ '3.0', 3.3, jruby-9.4 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 3.0, 3.3, jruby-9.4 ]
+        ruby: [ '3.0', 3.3, jruby-9.4 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added an API Generator ([#233](https://github.com/opensearch-project/opensearch-ruby/issues/233))
 - Added a workflow to generate API methods from OpenSearch API Spec
+- Added support for Ruby 3.4 ([#265](https://github.com/opensearch-project/opensearch-ruby/pull/265))
 ### Changed
 - Restructured the API methods and modules to be more efficient and intuitive
 ### Deprecated


### PR DESCRIPTION
Note: This does a bit more than what is says in the title but it seems not worth to create individual PRs for that.

In https://github.com/opensearch-project/opensearch-ruby/commit/9f933d586654c04e734f7eb5455b6253c54ab5b7 CI was modified, and quotes for the ruby version `3.0` were removed/not added. But that actually causes it to resolve against the latest 3.X ruby (https://github.com/actions/runner/issues/849). Additionally, it removed testing against in-between Rubies. That seems a bit risky, so I added them back in one job at least so there are not too many extra checks being done.

Finally, test against Ruby 3.4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
