### PR TITLE
Fix: CI

### DIFF
--- a/.github/workflows/generate_api.yml
+++ b/.github/workflows/generate_api.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Update bundler
         run: |
           sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev
           bundle install
 
       - name: Generate API

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     env:
       TEST_OPENSEARCH_SERVER: http://localhost:9250
       PORT: 9250
-      FARADAY_VERSION: '~> 1.0'
+      FARADAY_VERSION: '~> 1'
     strategy:
       fail-fast: false
       matrix:
@@ -106,7 +106,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libcurl4-openssl-dev
-          sudo apt-get install ca-certificates
           ruby -v
           bundle install
       - name: Test Client Security

--- a/.github/workflows/test-unreleased.yml
+++ b/.github/workflows/test-unreleased.yml
@@ -3,12 +3,12 @@ name: Integration with Unreleased OpenSearch
 on:
   push:
     branches:
-      - "main"
+      - 'main'
     paths-ignore:
       - '*.md'
   pull_request:
     branches:
-      - "main"
+      - 'main'
     paths-ignore:
       - '*.md'
 
@@ -24,7 +24,7 @@ jobs:
         entry:
           - { ruby_version: '3.3', opensearch_ref: '1.x', jdk_version: '11' }
           - { ruby_version: '3.3', opensearch_ref: '2.x', jdk_version: '17' }
-          - { ruby_version: '3.3', opensearch_ref: 'main', jdk_version: '23' }
+          - { ruby_version: '3.3', opensearch_ref: 'main', jdk_version: '21' }
 
     steps:
       - uses: ruby/setup-ruby@v1
@@ -40,7 +40,7 @@ jobs:
       - name: Get OpenSearch branch top
         id: get-key
         working-directory: opensearch
-        run: echo key=`git log -1 --format='%H'` >> $GITHUB_OUTPUT
+        run: echo key=`git log -1 --format='%H'`-${{ matrix.entry.jdk_version }} >> $GITHUB_OUTPUT
 
       - name: Restore cached build
         id: cache-restore
@@ -60,7 +60,6 @@ jobs:
         if: steps.cache-restore.outputs.cache-hit != 'true'
         working-directory: opensearch
         run: ./gradlew :distribution:archives:linux-tar:assemble --stacktrace
-        
 
       - name: Save cached build
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test-unreleased.yml
+++ b/.github/workflows/test-unreleased.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   test:
     env:
+      FARADAY_VERSION: '~> 1'
       TEST_OPENSEARCH_SERVER: http://localhost:9200
       PORT: 9200
     runs-on: ubuntu-latest

--- a/.github/workflows/test-unreleased.yml
+++ b/.github/workflows/test-unreleased.yml
@@ -24,7 +24,7 @@ jobs:
         entry:
           - { ruby_version: '3.3', opensearch_ref: '1.x', jdk_version: '11' }
           - { ruby_version: '3.3', opensearch_ref: '2.x', jdk_version: '17' }
-          - { ruby_version: '3.3', opensearch_ref: 'main', jdk_version: '17' }
+          - { ruby_version: '3.3', opensearch_ref: 'main', jdk_version: '23' }
 
     steps:
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test-unreleased.yml
+++ b/.github/workflows/test-unreleased.yml
@@ -51,7 +51,6 @@ jobs:
 
       - name: Setup Java JDK
         uses: actions/setup-java@v4
-        if: steps.cache-restore.outputs.cache-hit != 'true'
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.entry.jdk_version }}

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ if ENV.key?('FARADAY_VERSION')
   gem 'httpclient'
   gem 'net-http-persistent'
   gem 'patron' unless defined? JRUBY_VERSION
-  gem 'typhoeus'
+  gem 'typhoeus', '~> 1.4'
 else
   gem 'faraday-httpclient'
   gem 'faraday-net_http_persistent'

--- a/Gemfile
+++ b/Gemfile
@@ -28,19 +28,16 @@ source 'https://rubygems.org'
 
 gem 'opensearch-ruby', path: __dir__, require: false
 
+# TODO: remove unnecessary dependencies
 gem 'ansi'
 gem 'bundler'
 gem 'cane'
-gem 'faraday-httpclient'
-gem 'faraday-net_http_persistent'
 gem 'hashie'
-gem 'httpclient'
 gem 'jbuilder'
 gem 'jsonify'
 gem 'minitest', '~> 5'
 gem 'minitest-reporters', '~> 1'
 gem 'mocha', '~> 2'
-gem 'net-http-persistent'
 gem 'pry'
 gem 'rake', '~> 13'
 gem 'rspec', '~> 3'
@@ -50,19 +47,27 @@ gem 'rubocop-rspec'
 gem 'shoulda-context'
 gem 'simplecov', '~> 0.17', '< 0.18'
 gem 'test-unit', '~> 2'
-gem 'typhoeus', '~> 1.4'
 gem 'webmock', '~> 2.0'
 gem 'yard'
 
-gem 'curb' unless defined? JRUBY_VERSION
-gem 'faraday-patron' unless defined? JRUBY_VERSION
-gem 'patron' unless defined? JRUBY_VERSION
+if defined? JRUBY_VERSION
+  gem 'manticore'
+  gem 'pry-nav'
+else
+  gem 'curb'
+  gem 'require-prof'
+  gem 'ruby-prof'
+end
 
-gem 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
-gem 'ruby-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
-
-gem 'manticore' if defined? JRUBY_VERSION
-gem 'pry-nav' if defined? JRUBY_VERSION
-
-gem 'faraday', ENV.fetch('FARADAY_VERSION', nil), require: false if ENV.key?('FARADAY_VERSION')
-gem 'faraday-typhoeus' if !ENV.key?('FARADAY_VERSION') && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
+if ENV.key?('FARADAY_VERSION')
+  gem 'faraday', ENV.fetch('FARADAY_VERSION'), require: false
+  gem 'httpclient'
+  gem 'net-http-persistent'
+  gem 'patron' unless defined? JRUBY_VERSION
+  gem 'typhoeus'
+else
+  gem 'faraday-httpclient'
+  gem 'faraday-net_http_persistent'
+  gem 'faraday-patron' unless defined? JRUBY_VERSION
+  gem 'faraday-typhoeus'
+end

--- a/spec/opensearch/transport/client_spec.rb
+++ b/spec/opensearch/transport/client_spec.rb
@@ -1762,6 +1762,38 @@ describe OpenSearch::Transport::Client do
         end
       end
 
+      context 'when typhoeus is used as an adapter', unless: jruby? do
+        before do
+          require 'typhoeus'
+        end
+
+        let(:options) do
+          { adapter: :typhoeus }
+        end
+
+        let(:adapter) do
+          client.transport.connections.first.connection.builder.adapter
+        end
+
+        it 'uses the typhoeus connection handler' do
+          expect(adapter).to eq('Faraday::Adapter::Typhoeus')
+        end
+
+        it 'keeps connections open' do
+          puts 'Testing with _cat/health'
+          puts client.perform_request('GET', '_cat/health')
+          puts 'Performing GET _nodes/stats/http'
+          response = client.perform_request('GET', '_nodes/stats/http')
+          connections_before = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
+          puts 'Start reloading connections'
+          client.transport.reload_connections!
+          puts 'Connections reloaded'
+          response = client.perform_request('GET', '_nodes/stats/http')
+          connections_after = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
+          expect(connections_after).to be >= (connections_before)
+        end
+      end
+
       context 'when patron is used as an adapter', unless: jruby? do
         before do
           require 'patron'
@@ -1777,33 +1809,6 @@ describe OpenSearch::Transport::Client do
 
         it 'uses the patron connection handler' do
           expect(adapter).to eq('Faraday::Adapter::Patron')
-        end
-
-        it 'keeps connections open' do
-          response = client.perform_request('GET', '_nodes/stats/http')
-          connections_before = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
-          client.transport.reload_connections!
-          response = client.perform_request('GET', '_nodes/stats/http')
-          connections_after = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
-          expect(connections_after).to be >= (connections_before)
-        end
-      end
-
-      context 'when typhoeus is used as an adapter', unless: jruby? do
-        before do
-          require 'typhoeus'
-        end
-
-        let(:options) do
-          { adapter: :typhoeus }
-        end
-
-        let(:adapter) do
-          client.transport.connections.first.connection.builder.adapter
-        end
-
-        it 'uses the patron connection handler' do
-          expect(adapter).to eq('Faraday::Adapter::Typhoeus')
         end
 
         it 'keeps connections open' do

--- a/spec/opensearch/transport/client_spec.rb
+++ b/spec/opensearch/transport/client_spec.rb
@@ -1762,38 +1762,6 @@ describe OpenSearch::Transport::Client do
         end
       end
 
-      context 'when typhoeus is used as an adapter', unless: jruby? do
-        before do
-          require 'typhoeus'
-        end
-
-        let(:options) do
-          { adapter: :typhoeus }
-        end
-
-        let(:adapter) do
-          client.transport.connections.first.connection.builder.adapter
-        end
-
-        it 'uses the typhoeus connection handler' do
-          expect(adapter).to eq('Faraday::Adapter::Typhoeus')
-        end
-
-        it 'keeps connections open' do
-          puts 'Testing with _cat/health'
-          puts client.perform_request('GET', '_cat/health')
-          puts 'Performing GET _nodes/stats/http'
-          response = client.perform_request('GET', '_nodes/stats/http')
-          connections_before = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
-          puts 'Start reloading connections'
-          client.transport.reload_connections!
-          puts 'Connections reloaded'
-          response = client.perform_request('GET', '_nodes/stats/http')
-          connections_after = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
-          expect(connections_after).to be >= (connections_before)
-        end
-      end
-
       context 'when patron is used as an adapter', unless: jruby? do
         before do
           require 'patron'
@@ -1809,6 +1777,33 @@ describe OpenSearch::Transport::Client do
 
         it 'uses the patron connection handler' do
           expect(adapter).to eq('Faraday::Adapter::Patron')
+        end
+
+        it 'keeps connections open' do
+          response = client.perform_request('GET', '_nodes/stats/http')
+          connections_before = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
+          client.transport.reload_connections!
+          response = client.perform_request('GET', '_nodes/stats/http')
+          connections_after = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
+          expect(connections_after).to be >= (connections_before)
+        end
+      end
+
+      context 'when typhoeus is used as an adapter', unless: jruby? do
+        before do
+          require 'typhoeus'
+        end
+
+        let(:options) do
+          { adapter: :typhoeus }
+        end
+
+        let(:adapter) do
+          client.transport.connections.first.connection.builder.adapter
+        end
+
+        it 'uses the typhoeus connection handler' do
+          expect(adapter).to eq('Faraday::Adapter::Typhoeus')
         end
 
         it 'keeps connections open' do


### PR DESCRIPTION
### Description

On top of #266. 

- Fixes caching to allow switching JDKs.
- Downgrades Faraday, the issue of typhoeus is likely some incompatibility with Faraday 2.x, but that project has been dead for 3 years or so.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
