### PR TITLE
Change the default serializer to the `json` gem for 4.0.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Restructured the API methods and modules to be more efficient and intuitive ([261](https://github.com/opensearch-project/opensearch-ruby/pull/261))
 - Moved ignore-404-on-deletion feature into the client options ([#277](https://github.com/opensearch-project/opensearch-ruby/pull/277))
+- Changed the default json serializer from `multi_json` to the `json` gem ([#290](https://github.com/opensearch-project/opensearch-ruby/pull/290))
 ### Removed
 - Removed support for Ruby 2.x ([261](https://github.com/opensearch-project/opensearch-ruby/pull/261))
 - Removed the ability to ignore any error code by passing the `ignore: Array<error_code>` to each API method invocation ([#277](https://github.com/opensearch-project/opensearch-ruby/pull/277))

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,7 @@ Major versions of OpenSearch introduce breaking changes that require careful upg
 - The lesser-known ability to ignore any error code by passing the `ignore: Array<error_code>` to each API method invocation is deemed unnecessary and dangerous. This feature has been removed in OpenSearch Ruby 4.
 - The ability to pass an `opaque_id` parameter into an API method invocation to set the value of the `X-Opaque-Id` header has been removed. The user should now set the `X-Opaque-Id` header as part of the `headers` parameter in the API method invocation directly.
 - OpenSearch Ruby 4 received a major refactor to remove middle-man `perform_request` methods. While this does not affect the vast majority of use cases, applications or wrappers that rely on these methods should be updated. For more information, check the `How the perform_request method is invoked` section of this [PR](https://github.com/opensearch-project/opensearch-ruby/pull/261).
+- The default serializer was switched from `multi_json` to the `json` gem. If you want to still use `multi_json`, you can easily achieve it by implementing a [custom serializer](guides/transport_options.md#serializer-implementations).
 ## Upgrade to OpenSearch Ruby 3
 In Version 3 of the OpenSearch Ruby client, we have added the `api` and `transport` modules as the core components of the gem, instead of treating them as separate gems that are required by the `opensearch-ruby` gem. This removes the confusions around compatibility between the ruby client, its legacy dependencies, and the OpenSearch cluster.
 

--- a/api_generator/lib/templates/api.mustache
+++ b/api_generator/lib/templates/api.mustache
@@ -11,7 +11,7 @@ module OpenSearch
     {{/global_query_params}}
     ]).freeze
 
-    DEFAULT_SERIALIZER = MultiJson
+    DEFAULT_SERIALIZER = Transport::Transport::Serializer::JSON.new
 
     def self.serializer
       settings[:serializer] || DEFAULT_SERIALIZER

--- a/guides/transport_options.md
+++ b/guides/transport_options.md
@@ -383,7 +383,7 @@ You can write your own transport implementation easily, by including the {OpenSe
 
 ### Serializer Implementations
 
-By default, the [MultiJSON](http://rubygems.org/gems/multi_json) library is used as the serializer implementation, and it will pick up the "right" adapter based on gems available.
+By default, the [json](https://rubygems.org/gems/json) library is used as the serializer implementation.
 
 The serialization component is pluggable, though, so you can write your own by including the {OpenSearch::Transport::Transport::Serializer::Base} module, implementing the required contract, and passing it to the client as the `serializer_class` or `serializer` parameter.
 

--- a/lib/opensearch/api.rb
+++ b/lib/opensearch/api.rb
@@ -19,7 +19,7 @@ module OpenSearch
       'filter_path'     # Used to reduce the response. This parameter takes a comma-separated list of filters. It supports using wildcards to match any field or part of a field’s name. You can also exclude fields with "-".
     ]).freeze
 
-    DEFAULT_SERIALIZER = MultiJson
+    DEFAULT_SERIALIZER = Transport::Transport::Serializer::JSON.new
 
     def self.serializer
       settings[:serializer] || DEFAULT_SERIALIZER

--- a/lib/opensearch/transport.rb
+++ b/lib/opensearch/transport.rb
@@ -27,11 +27,11 @@
 require 'uri'
 require 'time'
 require 'timeout'
-require 'multi_json'
+require 'json'
 require 'faraday'
 
 require 'opensearch/transport/transport/loggable'
-require 'opensearch/transport/transport/serializer/multi_json'
+require 'opensearch/transport/transport/serializer/json'
 require 'opensearch/transport/transport/sniffer'
 require 'opensearch/transport/transport/response'
 require 'opensearch/transport/transport/errors'

--- a/lib/opensearch/transport/transport/base.rb
+++ b/lib/opensearch/transport/transport/base.rb
@@ -37,7 +37,7 @@ module OpenSearch
         DEFAULT_RELOAD_AFTER     = 10_000 # Requests
         DEFAULT_RESURRECT_AFTER  = 60     # Seconds
         DEFAULT_MAX_RETRIES      = 3      # Requests
-        DEFAULT_SERIALIZER_CLASS = Serializer::MultiJson
+        DEFAULT_SERIALIZER_CLASS = Serializer::JSON
         SANITIZED_PASSWORD       = '*' * rand(1..14)
 
         attr_reader   :hosts, :options, :connections, :counter, :last_request_at, :protocol

--- a/lib/opensearch/transport/transport/serializer/json.rb
+++ b/lib/opensearch/transport/transport/serializer/json.rb
@@ -38,21 +38,25 @@ module OpenSearch
           end
         end
 
-        # A default JSON serializer (using [MultiJSON](http://rubygems.org/gems/multi_json))
+        # A default JSON serializer (using [json](http://rubygems.org/gems/json))
         #
-        class MultiJson
+        class JSON
           include Base
 
           # De-serialize a Hash from JSON string
           #
           def load(string, options = {})
-            ::MultiJson.load(string, options)
+            ::JSON.parse(string, options)
           end
 
           # Serialize a Hash to JSON string
           #
           def dump(object, options = {})
-            ::MultiJson.dump(object, options)
+            if options.delete(:pretty)
+              ::JSON.pretty_generate(object, options)
+            else
+              ::JSON.generate(object, options)
+            end
           end
         end
       end

--- a/lib/opensearch/version.rb
+++ b/lib/opensearch/version.rb
@@ -25,5 +25,5 @@
 # under the License.
 
 module OpenSearch
-  VERSION = '4.0.0-beta.4'.freeze
+  VERSION = '4.0.0-beta.5'.freeze
 end

--- a/opensearch-ruby.gemspec
+++ b/opensearch-ruby.gemspec
@@ -66,5 +66,4 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '>= 1.0', '< 3'
   s.add_dependency "logger"
-  s.add_dependency 'multi_json', '>= 1.0'
 end

--- a/spec/opensearch/api/api_spec.rb
+++ b/spec/opensearch/api/api_spec.rb
@@ -33,7 +33,7 @@ describe OpenSearch::API do
     end
 
     it 'has a default serializer' do
-      expect(OpenSearch::API.serializer).to eq(MultiJson)
+      expect(OpenSearch::API.serializer).to be_a(OpenSearch::Transport::Transport::Serializer::JSON)
     end
 
     context 'when settings are changed' do

--- a/spec/opensearch/api/utils_spec.rb
+++ b/spec/opensearch/api/utils_spec.rb
@@ -191,11 +191,11 @@ describe OpenSearch::API::Utils do
       end
 
       let(:header) do
-        MultiJson.load(lines.first)
+        JSON.parse(lines.first)
       end
 
       let(:data_string) do
-        MultiJson.load(lines.last)
+        JSON.parse(lines.last)
       end
 
       it 'does not mutate the input' do

--- a/test/transport/unit/serializer_test.rb
+++ b/test/transport/unit/serializer_test.rb
@@ -30,11 +30,11 @@ class OpenSearch::Transport::Transport::SerializerTest < Minitest::Test
 
   context "Serializer" do
 
-    should "use MultiJson by default" do
-      ::MultiJson.expects(:load)
-      ::MultiJson.expects(:dump)
-      OpenSearch::Transport::Transport::Serializer::MultiJson.new.load('{}')
-      OpenSearch::Transport::Transport::Serializer::MultiJson.new.dump({})
+    should "use JSON by default" do
+      ::JSON.expects(:parse)
+      ::JSON.expects(:generate)
+      OpenSearch::Transport::Transport::Serializer::JSON.new.load('{}')
+      OpenSearch::Transport::Transport::Serializer::JSON.new.dump({})
     end
 
   end


### PR DESCRIPTION
### Description
Historically, the `json` gem that is default from ruby has been somewhat slow compared to other available implementations like the `oj` gem. Gems like `multi_json` exist to allow people to choose which backend they want to use. For example, to use `oj`, one has to simply add it to their gemfile and then use `MultiJson.load` and it will automatically use the `oj` gem.

Over the last few months there has been some great work to make the default `json` implementation in ruby more performant. In the following script, `json` used to be 1.5x times slower, now it is 1.4x times faster compared to `oj`:

<details><summary>Benchmark</summary>
<p>

```rb
require "bundler/inline"

gemfile do
  source 'https://rubygems.org'
  gem 'json'
  gem 'multi_json'
  gem 'oj'
  gem 'benchmark-ips'
end

# https://github.com/ruby/json/blob/3e025f76d77e323b30f6f6d2d8d06e787d497a0c/benchmark/data/twitter.json
data = File.read("twitter.json")

pp MultiJson.adapter

Benchmark.ips do |x|
  x.report("json") do
    JSON.parse(data)
  end

  x.report("multi_json") do
    MultiJson.load(data)
  end

  x.compare!
end
```

```
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [x86_64-linux]
Warming up --------------------------------------
                json    56.000 i/100ms
          multi_json    42.000 i/100ms
Calculating -------------------------------------
                json    570.026 (± 5.3%) i/s    (1.75 ms/i) -      2.856k in   5.025704s
          multi_json    417.460 (± 2.4%) i/s    (2.40 ms/i) -      2.100k in   5.033273s

Comparison:
                json:      570.0 i/s
          multi_json:      417.5 i/s - 1.37x  slower
```

</p>
</details> 

You can read more about this work on the blog of the person who is responsible for these improvements here: https://byroot.github.io/ruby/json/2024/12/15/optimizing-ruby-json-part-1.html. It is 7 parts and contains many other benchmarks and interesting information.

So, at this moment using `multi_json` is actually making things worse (if `oj` is in the gemfile) because it considers `oj` to be the preferable option. `multi_json` is in maintenance mode as per a maintainer https://github.com/intridea/multi_json/issues/198#issuecomment-660585225 and not recommended anymore for new projects. There has also been no release in the last 5 years (but to be fair, last year there were many commits made by a different person, so not entirely a dead project).

Anyways, I do not think there is any value in shipping with support for `multi_json` today anymore. If for some reason people want to use a different parser, they can easily accomplish this by implementing a custom serializer. So, for `opensearch-ruby` 4 I want to default to just using the `json` gem instead.

### Issues Resolved
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
