### PR TITLE
Remove support for faraday 1.X

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,40 +48,6 @@ jobs:
       - name: Run All Tests
         run: rake test:all
 
-  test-opensearch-faraday-1:
-    env:
-      TEST_OPENSEARCH_SERVER: http://localhost:9250
-      PORT: 9250
-      FARADAY_VERSION: '~> 1'
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: [ '3.0', 3.4, jruby-10.0 ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Increase system limits
-        run: |
-          sudo swapoff -a
-          sudo sysctl -w vm.swappiness=1
-          sudo sysctl -w fs.file-max=262144
-          sudo sysctl -w vm.max_map_count=262144
-      - uses: ./.github/actions/opensearch
-        with:
-          cluster-version: latest
-          disable-security: true
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-      - name: Build and test with Rake
-        run: |
-          sudo apt-get update
-          sudo apt-get install libcurl4-openssl-dev
-          ruby -v
-          bundle install
-      - name: Test Faraday on Transport Layer
-        run: rake test:transport:all
-
   test-opensearch-security:
     env:
       TEST_OPENSEARCH_SERVER: https://admin:myStrongPassword123!@localhost:9200

--- a/.github/workflows/test-unreleased.yml
+++ b/.github/workflows/test-unreleased.yml
@@ -19,7 +19,6 @@ on:
 jobs:
   test:
     env:
-      FARADAY_VERSION: '~> 1'
       TEST_OPENSEARCH_SERVER: http://localhost:9200
       PORT: 9200
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed support for Ruby 2.x ([261](https://github.com/opensearch-project/opensearch-ruby/pull/261))
 - Removed the ability to ignore any error code by passing the `ignore: Array<error_code>` to each API method invocation ([#277](https://github.com/opensearch-project/opensearch-ruby/pull/277))
 - Removed ability to set `X-Opaque-Id` header value via the `opaque_id` parameter. ([#287](https://github.com/opensearch-project/opensearch-ruby/pull/287))
+- Removed support for Faraday 1.x. ([#293](https://github.com/opensearch-project/opensearch-ruby/pull/293))
 
 ## [3.4.0]
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -62,15 +62,7 @@ else
   gem 'ruby-prof'
 end
 
-if ENV.key?('FARADAY_VERSION')
-  gem 'faraday', ENV.fetch('FARADAY_VERSION'), require: false
-  gem 'httpclient'
-  gem 'net-http-persistent'
-  gem 'patron' unless defined? JRUBY_VERSION
-  gem 'typhoeus', '~> 1.4'
-else
-  gem 'faraday-httpclient'
-  gem 'faraday-net_http_persistent'
-  gem 'faraday-patron' unless defined? JRUBY_VERSION
-  gem 'faraday-typhoeus'
-end
+gem 'faraday-httpclient'
+gem 'faraday-net_http_persistent'
+gem 'faraday-patron' unless defined? JRUBY_VERSION
+gem 'faraday-typhoeus'

--- a/README.md
+++ b/README.md
@@ -59,13 +59,11 @@ If you don't use Bundler, you may need to require the library explicitly (like `
 
 Currently these libraries will be automatically detected and used:
 - [Patron](https://github.com/toland/patron) through [faraday-patron](https://github.com/lostisland/faraday-patron)
-- [Typhoeus](https://github.com/typhoeus/typhoeus) through [faraday-typhoeus](https://github.com/dleavitt/faraday-typhoeus) for Faraday 2 or higher, or Faraday's built-in adapter for Faraday 1.
+- [Typhoeus](https://github.com/typhoeus/typhoeus) through [faraday-typhoeus](https://github.com/dleavitt/faraday-typhoeus)
 - [HTTPClient](https://rubygems.org/gems/httpclient) through [faraday-httpclient](https://github.com/lostisland/faraday-httpclient)
 - [Net::HTTP::Persistent](https://rubygems.org/gems/net-http-persistent) through [faraday-net_http_persistent](https://github.com/lostisland/faraday-net_http_persistent)
 
 **Note on [Typhoeus](https://github.com/typhoeus/typhoeus)**: You need to use v1.4.0 or up since older versions are not compatible with Faraday 1.0 or higher.
-
-**Note on [Faraday](https://rubygems.org/gems/faraday)**: If you use Faraday 2.0 or higher, if the adapter is in a separate gem, you will likely need to declare that gem as well. Only the Net::HTTP adapter gem is included by default. Faraday 1.x includes most common adapter gems already.
 
 ## DSL Features
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,7 @@ Major versions of OpenSearch introduce breaking changes that require careful upg
 
 ## Upgrade to OpenSearch Ruby 4
 - OpenSearch Ruby 4 drops support for Ruby 2.x. If you are using Ruby 2.x, you should upgrade to Ruby 3.x before upgrading to OpenSearch Ruby 4.
+- Support for Faraday 1.x was removed. Faraday 2 doesn't depend on the adapter gems anymore, so if you are using Faraday 1.x with a different library gem than the default you will need to include the adapter gem into your own Gemfile.
 - OpenSearch Ruby 4 has a different implementation of the `ignore 404 error` feature on all delete actions. Instead of passing `ingore: 404` as if it is a query parameter for each API action, this feature can now be toggled on and off (off by default) during the client instance instantiation. If you are using this feature, you should review the [Idempotent Delete](./guides/idempotent_delete.md) guide for the changes.
 - The lesser-known ability to ignore any error code by passing the `ignore: Array<error_code>` to each API method invocation is deemed unnecessary and dangerous. This feature has been removed in OpenSearch Ruby 4.
 - The ability to pass an `opaque_id` parameter into an API method invocation to set the value of the `X-Opaque-Id` header has been removed. The user should now set the `X-Opaque-Id` header as part of the `headers` parameter in the API method invocation directly.

--- a/lib/opensearch/transport/client.rb
+++ b/lib/opensearch/transport/client.rb
@@ -366,10 +366,8 @@ module OpenSearch
       #
       def __auto_detect_adapter
         # Get the Faraday adapter list without initializing it.
-        adapter = if Faraday::Adapter.respond_to?(:registered_middleware) # Faraday 2.x
+        adapter = if Faraday::Adapter.respond_to?(:registered_middleware)
                     ->(name) { Faraday::Adapter.registered_middleware[name] }
-                  elsif Faraday::Adapter.respond_to?(:fetch_middleware) # Faraday 1.x
-                    ->(name) { Faraday::Adapter.fetch_middleware(name) }
                   else
                     {} # fallback behavior that should never happen
                   end

--- a/opensearch-ruby.gemspec
+++ b/opensearch-ruby.gemspec
@@ -64,6 +64,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0'
 
-  s.add_dependency 'faraday', '>= 1.0', '< 3'
+  s.add_dependency 'faraday', '~> 2.0'
   s.add_dependency "logger"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,7 @@ if defined?(JRUBY_VERSION)
   require 'pry-nav'
 else
   require 'faraday/patron'
-  require 'faraday/typhoeus' if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2')
+  require 'faraday/typhoeus'
   require 'opensearch/transport/transport/http/curb'
   require 'curb'
 end

--- a/test/transport/integration/transport_test.rb
+++ b/test/transport/integration/transport_test.rb
@@ -37,7 +37,7 @@ class OpenSearch::Transport::ClientIntegrationTest < Minitest::Test
       # Require the library so autodetection finds it.
       require 'typhoeus'
       # Require the adapter so autodetection finds it.
-      require 'faraday/typhoeus' if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2')
+      require 'faraday/typhoeus'
 
       transport = OpenSearch::Transport::Transport::HTTP::Faraday.new \
         :hosts => [ { host: @host, port: @port } ] do |f|


### PR DESCRIPTION
### Description
Faraday 2 has been out for a few years now already. As discussed in https://github.com/opensearch-project/opensearch-ruby/pull/290#issuecomment-2832292922


### Issues Resolved
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
