### PR TITLE
Adapt CI for opensearch 3

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cluster-version: [ "1.3.3", "2.0.1", "2" ]
+        cluster-version: [ "1.3.3", "2.0.1", "2", "3.0.0", "3"  ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cluster-version: [ "1.3.3", "2.0.1", "2.18.0" ]
+        cluster-version: [ "1.3.3", "2.0.1", "2" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
       - uses: ./.github/actions/opensearch
         with:
-          cluster-version: 2.18.0
+          cluster-version: latest
           disable-security: true
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test-unreleased.yml
+++ b/.github/workflows/test-unreleased.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { ruby_version: '3.3', opensearch_ref: '1.x', jdk_version: '11' }
           - { ruby_version: '3.3', opensearch_ref: '2.x', jdk_version: '17' }
           - { ruby_version: '3.3', opensearch_ref: 'main', jdk_version: '21' }
 


### PR DESCRIPTION
### Description
Add OpenSearch 3 to CI since it is now GA. I made a few commits, see their message for rationale for each.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-ruby/issues/294

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
