### PR TITLE
Only require what is necessary from `cgi` for Ruby 3.5

### DIFF
--- a/lib/opensearch/api/utils.rb
+++ b/lib/opensearch/api/utils.rb
@@ -9,7 +9,7 @@
 
 # frozen_string_literal: true
 
-require 'cgi'
+require 'cgi/escape'
 
 module OpenSearch
   module API


### PR DESCRIPTION
### Description

In Ruby 3.5, most of the `cgi` gem is removed. Only methods relating to escaping/unescaping are retained.

Those are the only thing that's being used, so use the more specific require and avoid the warning that would otherwise be emitted. Doing it like this works since Ruby 2.4.

https://bugs.ruby-lang.org/issues/21258

### Issues Resolved

None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
