### PR TITLE
Only have one open PR for api spec updates

### DIFF
--- a/.github/workflows/generate_api.yml
+++ b/.github/workflows/generate_api.yml
@@ -73,7 +73,7 @@ jobs:
           body: |
             Update `opensearch-ruby` to reflect the latest [OpenSearch API spec](https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml).
             Date: ${{ env.date }}
-          branch: update-api-from-spec-${{ env.date }}
+          branch: update-api-from-spec
           base: main
           signoff: true
           labels: |


### PR DESCRIPTION
### Description
https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#action-behaviour
> If a pull request already exists it will be updated if necessary.

This way there aren't a bunch of open PRs if no one merges. Per the docs, the currently open one should simply be force-pushed/updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
