### PR TITLE
wrap `host_unreachable_exceptions` in `OpenSearch::Transport::Transport::Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed the ability to ignore any error code by passing the `ignore: Array<error_code>` to each API method invocation ([#277](https://github.com/opensearch-project/opensearch-ruby/pull/277))
 - Removed ability to set `X-Opaque-Id` header value via the `opaque_id` parameter. ([#287](https://github.com/opensearch-project/opensearch-ruby/pull/287))
 - Removed support for Faraday 1.x. ([#293](https://github.com/opensearch-project/opensearch-ruby/pull/293))
+- Wrapped unreachable host exceptions in `OpenSearch::Transport::Transport::Error`. ([#317](https://github.com/opensearch-project/opensearch-ruby/pull/317))
 
 ## [3.4.0]
 ### Added

--- a/lib/opensearch/transport/transport/base.rb
+++ b/lib/opensearch/transport/transport/base.rb
@@ -319,13 +319,15 @@ module OpenSearch
               reload_connections! and retry
             end
 
-            raise e unless max_retries
+            exception = OpenSearch::Transport::Transport::Error.new(e.message)
+
+            raise exception unless max_retries
             log_warn "[#{e.class}] Attempt #{tries} connecting to #{connection.host.inspect}"
             if tries <= max_retries
               retry
             else
               log_fatal "[#{e.class}] Cannot connect to #{connection.host.inspect} after #{tries} tries"
-              raise e
+              raise exception
             end
           rescue StandardError => e
             log_fatal "[#{e.class}] #{e.message} (#{connection.host.inspect if connection})"

--- a/spec/opensearch/transport/base_spec.rb
+++ b/spec/opensearch/transport/base_spec.rb
@@ -42,14 +42,14 @@ describe OpenSearch::Transport::Transport::Base do
 
         expect {
           client.perform_request('GET', '_cluster/stats')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        }.to raise_exception(OpenSearch::Transport::Transport::Error)
       end
 
       it 'replaces the password with the string \'REDACTED\'' do
         expect(logger).to receive(:error).with(/REDACTED/)
         expect {
           client.perform_request('GET', '_cluster/stats')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        }.to raise_exception(OpenSearch::Transport::Transport::Error)
       end
     end
 
@@ -142,7 +142,7 @@ describe OpenSearch::Transport::Transport::Base do
     end
 
     it 'raises an exception' do
-      expect { client.perform_request('GET', '/') }.to raise_exception(Faraday::ConnectionFailed)
+      expect { client.perform_request('GET', '/') }.to raise_exception(OpenSearch::Transport::Transport::Error)
     end
   end
 
@@ -166,7 +166,7 @@ describe OpenSearch::Transport::Transport::Base do
       it 'uses the client `retry_on_failure` value' do
         expect {
           client.transport.perform_request('GET', '/info')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        }.to raise_exception(OpenSearch::Transport::Transport::Error)
       end
     end
 
@@ -197,7 +197,7 @@ describe OpenSearch::Transport::Transport::Base do
       it 'uses the option `retry_on_failure` value' do
         expect do
           client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
-        end.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(OpenSearch::Transport::Transport::Error)
       end
     end
   end
@@ -222,7 +222,7 @@ describe OpenSearch::Transport::Transport::Base do
       it 'uses the default `MAX_RETRIES` value' do
         expect {
           client.transport.perform_request('GET', '/info')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        }.to raise_exception(OpenSearch::Transport::Transport::Error)
       end
     end
 
@@ -234,7 +234,7 @@ describe OpenSearch::Transport::Transport::Base do
       it 'uses the option `retry_on_failure` value' do
         expect {
           client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
-        }.to raise_exception(Faraday::ConnectionFailed)
+        }.to raise_exception(OpenSearch::Transport::Transport::Error)
       end
     end
   end
@@ -259,7 +259,7 @@ describe OpenSearch::Transport::Transport::Base do
       it 'does not retry' do
         expect {
           client.transport.perform_request('GET', '/info')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        }.to raise_exception(OpenSearch::Transport::Transport::Error)
       end
     end
 
@@ -272,7 +272,7 @@ describe OpenSearch::Transport::Transport::Base do
       it 'uses the option `retry_on_failure` value' do
         expect {
           client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
-        }.to raise_exception(Faraday::ConnectionFailed)
+        }.to raise_exception(OpenSearch::Transport::Transport::Error)
       end
     end
   end
@@ -294,7 +294,7 @@ describe OpenSearch::Transport::Transport::Base do
       it 'does not retry' do
         expect do
           client.transport.perform_request('GET', '/info')
-        end.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(OpenSearch::Transport::Transport::Error)
       end
     end
 
@@ -306,7 +306,7 @@ describe OpenSearch::Transport::Transport::Base do
       it 'uses the option `retry_on_failure` value' do
         expect do
           client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
-        end.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(OpenSearch::Transport::Transport::Error)
       end
     end
   end

--- a/spec/opensearch/transport/client_spec.rb
+++ b/spec/opensearch/transport/client_spec.rb
@@ -1492,7 +1492,7 @@ describe OpenSearch::Transport::Client do
           expect(client.perform_request('GET', '_nodes/_local'))
           expect {
             client.perform_request('GET', '_nodes/_local')
-          }.to raise_exception(Faraday::ConnectionFailed)
+          }.to raise_exception(OpenSearch::Transport::Transport::Error)
         end
       end
 

--- a/test/transport/unit/transport_base_test.rb
+++ b/test/transport/unit/transport_base_test.rb
@@ -267,7 +267,7 @@ class OpenSearch::Transport::Transport::BaseTest < Minitest::Test
       # `block.expects(:call).raises(::Errno::ECONNREFUSED)` fails on Ruby 1.8
       block = lambda { |a,b| raise ::Errno::ECONNREFUSED }
 
-      assert_raise ::Errno::ECONNREFUSED do
+      assert_raise OpenSearch::Transport::Transport::Error do
         @transport.perform_request 'GET', '/', &block
       end
     end
@@ -289,7 +289,7 @@ class OpenSearch::Transport::Transport::BaseTest < Minitest::Test
 
       c.expects(:dead!)
 
-      assert_raise( ::Errno::ECONNREFUSED ) { @transport.perform_request 'GET', '/', &block }
+      assert_raise(OpenSearch::Transport::Transport::Error) { @transport.perform_request 'GET', '/', &block }
     end
   end
 
@@ -343,7 +343,7 @@ class OpenSearch::Transport::Transport::BaseTest < Minitest::Test
             then.raises(Errno::ECONNREFUSED).
             then.returns(stub_everything :failures => 1)
 
-      assert_raise Errno::ECONNREFUSED do
+      assert_raise OpenSearch::Transport::Transport::Error do
         @transport.perform_request('GET', '/', &@block)
       end
     end


### PR DESCRIPTION
As mentioned in the [transport options guide](https://github.com/opensearch-project/opensearch-ruby/blob/3.4.0/guides/transport_options.md), any server errors will always be raised as `OpenSearch::Transport::Transport::Error`. In the case of `host_unreachable_exceptions` however, that was not the case.

Now it is!

This is very similar to elastic/elastic-transport-ruby#45.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
