### PR TITLE
Move dblock to emeritus maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @VijayanB @robsears @vamshin @dblock @VachaShah @nhtruong @harshavamsi @Earlopain
+* @VijayanB @robsears @vamshin @VachaShah @nhtruong @harshavamsi @Earlopain

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,21 +6,21 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer              | GitHub ID                                       | Affiliation |
-| ----------------------- | ----------------------------------------------- | ----------- |
-| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)         | Amazon      |
-| Rob Sears               | [robsears](https://github.com/robsears)         | Bonsai      |
-| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)           | Amazon      |
-| Daniel Doubrovkine      | [dblock](https://github.com/dblock)             | Independent |
-| Vacha Shah              | [VachaShah](https://github.com/VachaShah)       | Amazon      |
-| Theo Truong             | [nhtruong](https://github.com/nhtruong)         | Amazon      |
-| Harsha Vamsi Kalluri    | [harshavamsi](https://github.com/harshavamsi)   | Amazon      |
-| Earlopain               | [Earlopain](https://github.com/Earlopain)       |             |
+| Maintainer              | GitHub ID                                     | Affiliation |
+| ----------------------- | --------------------------------------------- | ----------- |
+| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)       | Amazon      |
+| Rob Sears               | [robsears](https://github.com/robsears)       | Bonsai      |
+| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)         | Amazon      |
+| Vacha Shah              | [VachaShah](https://github.com/VachaShah)     | Amazon      |
+| Theo Truong             | [nhtruong](https://github.com/nhtruong)       | Amazon      |
+| Harsha Vamsi Kalluri    | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
+| Earlopain               | [Earlopain](https://github.com/Earlopain)     |             |
 
 
 ## Emeritus
 
-| Maintainer              | GitHub ID                                       | Affiliation |
-|-------------------------|-------------------------------------------------|-------------|
-| Yuvraj Jaiswal          | [yuvi17](https://github.com/yuvi17)             | Amazon      |
-| Jayesh Hathila          | [jayeshathila](https://github.com/jayeshathila) | Amazon      |
+| Maintainer         | GitHub ID                                       | Affiliation |
+| ------------------ | ----------------------------------------------- | ----------- |
+| Daniel Doubrovkine | [dblock](https://github.com/dblock)             | Independent |
+| Yuvraj Jaiswal     | [yuvi17](https://github.com/yuvi17)             | Amazon      |
+| Jayesh Hathila     | [jayeshathila](https://github.com/jayeshathila) | Amazon      |


### PR DESCRIPTION
## Summary
- Moved dblock to emeritus maintainers section
- Removed dblock from CODEOWNERS

🤖 Generated with [Claude Code](https://claude.com/claude-code)