### PR TITLE
Add exponential backoff to retry logic in perform_request

### DIFF
--- a/lib/opensearch/transport/client.rb
+++ b/lib/opensearch/transport/client.rb
@@ -99,6 +99,12 @@ module OpenSearch
       #                                                        exception (false by default)
       # @option arguments Array<Number> :retry_on_status Retry when specific status codes are returned
       #
+      # @option arguments [Number] :retry_backoff         Base delay in seconds before retrying (nil by default,
+      #                                                   meaning no delay between retries). When set, retries will
+      #                                                   sleep with exponential backoff: retry_backoff * (retry_backoff_factor ** (attempt - 1))
+      #                                                   with up to 25% random jitter.
+      # @option arguments [Number] :retry_backoff_factor  Multiplier for exponential backoff (2 by default)
+      #
       # @option arguments [Boolean] :reload_on_failure Reload connections after failure (false by default)
       #
       # @option arguments [Boolean] :ignore_404_on_delete Whether to ignore 404/NotFound error on http DELETE (false by default)

--- a/lib/opensearch/transport/transport/base.rb
+++ b/lib/opensearch/transport/transport/base.rb
@@ -81,6 +81,9 @@ module OpenSearch
           @reload_after    = options[:reload_connections].is_a?(Integer) ? options[:reload_connections] : DEFAULT_RELOAD_AFTER
           @resurrect_after = options[:resurrect_after] || DEFAULT_RESURRECT_AFTER
           @retry_on_status = Array(options[:retry_on_status]).map(&:to_i)
+
+          @retry_backoff        = options[:retry_backoff]
+          @retry_backoff_factor = options[:retry_backoff_factor] || 2
         end
 
         # Returns a connection from the connection pool by delegating to {Connections::Collection#get_connection}.
@@ -304,6 +307,7 @@ module OpenSearch
             raise e unless response && @retry_on_status.include?(response.status)
             log_warn "[#{e.class}] Attempt #{tries} to get response from #{url}"
             if tries <= (max_retries || DEFAULT_MAX_RETRIES)
+              __retry_backoff_sleep(tries)
               retry
             else
               log_fatal "[#{e.class}] Cannot get response from #{url} after #{tries} tries"
@@ -316,6 +320,7 @@ module OpenSearch
 
             if reload_on_failure && (tries < connections.all.size)
               log_warn "[#{e.class}] Reloading connections (attempt #{tries} of #{connections.all.size})"
+              __retry_backoff_sleep(tries)
               reload_connections! and retry
             end
 
@@ -324,6 +329,7 @@ module OpenSearch
             raise exception unless max_retries
             log_warn "[#{e.class}] Attempt #{tries} connecting to #{connection.host.inspect}"
             if tries <= max_retries
+              __retry_backoff_sleep(tries)
               retry
             else
               log_fatal "[#{e.class}] Cannot connect to #{connection.host.inspect} after #{tries} tries"
@@ -381,6 +387,25 @@ module OpenSearch
         end
 
         private
+
+        # Sleeps with exponential backoff before a retry attempt, if `retry_backoff` is configured.
+        #
+        # The delay is calculated as: retry_backoff * (retry_backoff_factor ** (tries - 1))
+        # with up to 25% random jitter to avoid thundering herd effects.
+        #
+        # @param tries [Integer] The current attempt number (1-based)
+        #
+        # @api private
+        #
+        def __retry_backoff_sleep(tries)
+          return unless @retry_backoff
+
+          delay = @retry_backoff * (@retry_backoff_factor**(tries - 1))
+          jitter = delay * rand * 0.25
+          sleep_duration = delay + jitter
+          log_warn "[Retry] Backing off for #{format('%.2f', sleep_duration)}s before retry ##{tries}"
+          sleep(sleep_duration)
+        end
 
         USER_AGENT_STR = 'User-Agent'.freeze
         USER_AGENT_REGEX = /user-?_?agent/

--- a/spec/opensearch/transport/base_spec.rb
+++ b/spec/opensearch/transport/base_spec.rb
@@ -310,4 +310,80 @@ describe OpenSearch::Transport::Transport::Base do
       end
     end
   end
+
+  context 'when the client has `retry_backoff` configured' do
+    let(:client) do
+      OpenSearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+        hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
+        retry_on_failure: 2,
+        retry_backoff: 1,
+        retry_backoff_factor: 2
+      }
+    end
+
+    context 'when a request fails and is retried' do
+      before do
+        allow(client.transport).to receive(:sleep)
+      end
+
+      it 'sleeps with exponential backoff before each retry' do
+        expect {
+          client.transport.perform_request('GET', '/info')
+        }.to raise_exception(OpenSearch::Transport::Transport::Error)
+
+        expect(client.transport).to have_received(:sleep).with(a_value_between(1.0, 1.25)).ordered
+        expect(client.transport).to have_received(:sleep).with(a_value_between(2.0, 2.5)).ordered
+      end
+    end
+
+    context 'when retry_backoff is not set' do
+      let(:arguments) do
+        {
+          hosts: ['http://unavailable:9200'],
+          retry_on_failure: 1
+        }
+      end
+
+      before do
+        allow(client.transport).to receive(:sleep)
+      end
+
+      it 'does not sleep between retries' do
+        expect {
+          client.transport.perform_request('GET', '/info')
+        }.to raise_exception(OpenSearch::Transport::Transport::Error)
+
+        expect(client.transport).not_to have_received(:sleep)
+      end
+    end
+
+    context 'when retrying on status codes' do
+      let(:arguments) do
+        {
+          hosts: OPENSEARCH_HOSTS,
+          retry_on_failure: 2,
+          retry_on_status: [404],
+          retry_backoff: 0.5,
+          retry_backoff_factor: 2
+        }
+      end
+
+      before do
+        allow(client.transport).to receive(:sleep)
+      end
+
+      it 'sleeps with exponential backoff on retry_on_status retries' do
+        expect {
+          client.transport.perform_request('GET', 'myindex/_doc/1?routing=FOOBARBAZ')
+        }.to raise_exception(OpenSearch::Transport::Transport::Errors::NotFound)
+
+        expect(client.transport).to have_received(:sleep).with(a_value_between(0.5, 0.625)).ordered
+        expect(client.transport).to have_received(:sleep).with(a_value_between(1.0, 1.25)).ordered
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description

Add `retry_backoff` and `retry_backoff_factor` options to the transport client, enabling exponential backoff between retries.

**Current behavior:** When `retry_on_failure` or `retry_on_status` triggers a retry, the client retries immediately with no delay. During cluster saturation, this compounds load.

**New behavior:** When `retry_backoff` is configured, the transport sleeps `retry_backoff * (retry_backoff_factor ** (attempt - 1))` seconds (with up to 25% random jitter) before each retry.

### Usage

```ruby
client = OpenSearch::Client.new(
  retry_on_failure: 3,
  retry_on_status: [429, 503],
  retry_backoff: 1,          # base delay in seconds (default: nil = no backoff, preserving existing behavior)
  retry_backoff_factor: 2    # exponential multiplier (default: 2)
)
# Retry delays: ~1s, ~2s, ~4s (with jitter)
```

### Changes

- **`lib/opensearch/transport/transport/base.rb`**: Store `retry_backoff` and `retry_backoff_factor` options in `initialize`. Add private `__retry_backoff_sleep` method. Call it before each `retry` in `perform_request` (ServerError, host_unreachable, and reload_on_failure paths).
- **`lib/opensearch/transport/client.rb`**: Document the new options.
- **`spec/opensearch/transport/base_spec.rb`**: Add tests for backoff on host_unreachable retries, no-sleep when unconfigured, and backoff on retry_on_status retries.

### Backward compatible

Yes — when `retry_backoff` is not set (the default), behavior is unchanged. No existing APIs or defaults are modified.

Closes #324

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.