### PR TITLE
Fix release workflows to use pre-releases and update releasing.md with new process

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -44,9 +44,9 @@ jobs:
           mkdir dist && mv opensearch-ruby-*.gem dist/
           tar -cvf artifacts.tar.gz dist
       - name: Draft a release
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
-          draft: true
-          generate_release_notes: true
-          files: |
-            artifacts.tar.gz
+          immutableCreate: true
+          generateReleaseNotes: true
+          artifacts: "artifacts.tar.gz"
+          prerelease: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,9 +33,14 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md). For this client, there are 5 gems that can be released: `opensearch-api`, `opensearch-ruby`, `opensearch-transport`, `opensearch-dsl` and `opensearch-aws-sigv4`.
 
-1. Create a tag for the releasing ruby gem, e.g. `opensearch-ruby/2.2.0`, and push it to the GitHub repo.
-1. The [release_drafter.yml](.github/workflows/release_drafter.yml) will be automatically kicked off and is responsible for drafting a new release on GitHub containing release artifacts.
-1. Before creating a draft release, this workflow creates a GitHub issue asking for approval from the [maintainers](MAINTAINERS.md). See sample [issue](https://github.com/gaiksaya/opensearch-ruby/issues/1). The maintainers need to approve in order to continue the workflow run.
-1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-ruby-gems-release/) as a result of which opensearch-ruby client gem is released on rubygems.
-1. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+1. Identify the commit to release and create a tag on it, pushing to the upstream repo:
+```
+git fetch origin
+git tag <tag-name> <commit-sha>
+git push origin <tag-name>
+```
+1. The [release_drafter.yml](.github/workflows/release_drafter.yml) will be automatically kicked off. Before creating a release, this workflow creates a GitHub issue asking for approval from the [maintainers](MAINTAINERS.md). The maintainers need to approve in order to continue the workflow run.
+1. Once approved, a pre-release will be created with the build artifacts attached.
+1. This pre-release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/opensearch-ruby-gems-release/) as a result of which opensearch-ruby client gem is released on rubygems. Please note that the release workflow is triggered only if created release is in pre-release state.
+1. Once the above release workflow is successful, it creates a GitHub issue requesting maintainers to manually publish the pre-release to release on GitHub.
 1. Increment "version" in related gems `version.rb` to the next patch release, e.g. v2.2.1.

--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@6.4.5', retriever: modernSCM([
+lib = library(identifier: 'jenkins@13.0.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -6,8 +6,7 @@ lib = library(identifier: 'jenkins@6.4.5', retriever: modernSCM([
 standardReleasePipelineWithGenericTrigger(
     tokenIdCredential: 'jenkins-opensearch-ruby-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-ruby repository causing this workflow to run',
-    downloadReleaseAsset: true,
-    publishRelease: true) {
+    downloadReleaseAsset: true) {
         publishToRubyGems(
             publicCertPath: ".github/opensearch-rubygems.pem",
             apiKeyCredentialId: 'jenkins-opensearch-ruby-api-key',


### PR DESCRIPTION
### Description
Recently we removed bot access to the repository. Due to which it is now unable to read draft releases.
This PR fixes it by creating pre-release first, trigger jenkins workflow and then creates GH issue requesting maintainers to publish the release on the GitHub as bot does not have access anymore.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6255

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
