### PR TITLE
Prepare 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 ### Changed
-- Update rubygems public key setting expiry to 20260707 ([#308](https://github.com/opensearch-project/opensearch-ruby/pull/308))
 ### Deprecated
 ### Removed
 ### Fixed
@@ -16,16 +15,22 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a workflow to generate API methods from OpenSearch API Spec ([261](https://github.com/opensearch-project/opensearch-ruby/pull/261))
 - Added support for Ruby 3.4 ([#265](https://github.com/opensearch-project/opensearch-ruby/pull/265))
 - Added ability to sign requests ([#281](https://github.com/opensearch-project/opensearch-ruby/pull/281))
+- Added `ml` memory container, agentic memory, and streaming actions (`create_memory_container`, `add_agentic_memory`, `search_agentic_memory`, `execute_agent_stream`, `predict_model_stream`, `execute_tool`, and related) from the latest OpenSearch API spec
+- Added `search_relevance` scheduled experiment actions (`get_scheduled_experiments`, `post_scheduled_experiments`, `delete_scheduled_experiments`) from the latest OpenSearch API spec
 ### Changed
 - Restructured the API methods and modules to be more efficient and intuitive ([261](https://github.com/opensearch-project/opensearch-ruby/pull/261))
 - Moved ignore-404-on-deletion feature into the client options ([#277](https://github.com/opensearch-project/opensearch-ruby/pull/277))
 - Changed the default json serializer from `multi_json` to the `json` gem ([#290](https://github.com/opensearch-project/opensearch-ruby/pull/290))
+- Updated the API to reflect the latest OpenSearch API spec ([#271](https://github.com/opensearch-project/opensearch-ruby/pull/271), [#276](https://github.com/opensearch-project/opensearch-ruby/pull/276), [#279](https://github.com/opensearch-project/opensearch-ruby/pull/279), [#280](https://github.com/opensearch-project/opensearch-ruby/pull/280), [#282](https://github.com/opensearch-project/opensearch-ruby/pull/282), [#284](https://github.com/opensearch-project/opensearch-ruby/pull/284), [#286](https://github.com/opensearch-project/opensearch-ruby/pull/286), [#296](https://github.com/opensearch-project/opensearch-ruby/pull/296), [#299](https://github.com/opensearch-project/opensearch-ruby/pull/299), [#314](https://github.com/opensearch-project/opensearch-ruby/pull/314), [#318](https://github.com/opensearch-project/opensearch-ruby/pull/318), [#320](https://github.com/opensearch-project/opensearch-ruby/pull/320)) and regenerated against the latest spec for the 4.0.0 release, adding a `msearch` `allow_partial_results` parameter
+- Wrapped unreachable host exceptions in `OpenSearch::Transport::Transport::Error` ([#317](https://github.com/opensearch-project/opensearch-ruby/pull/317))
+- Only require what is necessary from `cgi` for Ruby 3.5 ([#298](https://github.com/opensearch-project/opensearch-ruby/pull/298))
+- Update rubygems public key setting expiry to 20260707 ([#308](https://github.com/opensearch-project/opensearch-ruby/pull/308))
+- Update RubyGems signing certificate ([#330](https://github.com/opensearch-project/opensearch-ruby/pull/330))
 ### Removed
 - Removed support for Ruby 2.x ([261](https://github.com/opensearch-project/opensearch-ruby/pull/261))
 - Removed the ability to ignore any error code by passing the `ignore: Array<error_code>` to each API method invocation ([#277](https://github.com/opensearch-project/opensearch-ruby/pull/277))
 - Removed ability to set `X-Opaque-Id` header value via the `opaque_id` parameter. ([#287](https://github.com/opensearch-project/opensearch-ruby/pull/287))
 - Removed support for Faraday 1.x. ([#293](https://github.com/opensearch-project/opensearch-ruby/pull/293))
-- Wrapped unreachable host exceptions in `OpenSearch::Transport::Transport::Error`. ([#317](https://github.com/opensearch-project/opensearch-ruby/pull/317))
 
 ## [3.4.0]
 ### Added

--- a/lib/opensearch/api/actions/ml/add_agentic_memory.rb
+++ b/lib/opensearch/api/actions/ml/add_agentic_memory.rb
@@ -11,17 +11,22 @@
 
 module OpenSearch
   module API
-    module SearchRelevance
+    module Ml
       module Actions
-        # Creates a new query set by uploading manually.
+        # Add agentic memory to a memory container.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [String] :memory_container_id *Required*
+        # @option args [Hash] :body
+        def add_agentic_memory(args = {})
           args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'memory_container_id' missing" if args['memory_container_id'].nil?
+
+          _memory_container_id = args.delete('memory_container_id')
+
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = 'POST'
+          url     = Utils.build_url('_plugins/_ml/memory_containers', _memory_container_id, 'memories')
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/ml/create_memory_container.rb
+++ b/lib/opensearch/api/actions/ml/create_memory_container.rb
@@ -11,17 +11,17 @@
 
 module OpenSearch
   module API
-    module SearchRelevance
+    module Ml
       module Actions
-        # Creates a new query set by uploading manually.
+        # Create a memory container.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [Hash] :body
+        def create_memory_container(args = {})
           args = Utils.clone_and_normalize_arguments(args)
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = 'POST'
+          url     = '_plugins/_ml/memory_containers/_create'
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/ml/create_memory_container_session.rb
+++ b/lib/opensearch/api/actions/ml/create_memory_container_session.rb
@@ -11,17 +11,22 @@
 
 module OpenSearch
   module API
-    module SearchRelevance
+    module Ml
       module Actions
-        # Creates a new query set by uploading manually.
+        # Create session in a memory container.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [String] :memory_container_id *Required*
+        # @option args [Hash] :body
+        def create_memory_container_session(args = {})
           args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'memory_container_id' missing" if args['memory_container_id'].nil?
+
+          _memory_container_id = args.delete('memory_container_id')
+
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = 'POST'
+          url     = Utils.build_url('_plugins/_ml/memory_containers', _memory_container_id, 'memories/sessions')
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/ml/delete_agentic_memory.rb
+++ b/lib/opensearch/api/actions/ml/delete_agentic_memory.rb
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This file is generated from the OpenSearch REST API spec.
+# Do not modify it by hand. Instead, modify the generator or the spec.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Ml
+      module Actions
+        # Delete a specific memory by its type and ID.
+        #
+        # @option args [String] :id *Required*
+        # @option args [String] :memory_container_id *Required*
+        # @option args [String] :type *Required*
+        def delete_agentic_memory(args = {})
+          args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'id' missing" if args['id'].nil?
+          raise ArgumentError, "Required argument 'memory_container_id' missing" if args['memory_container_id'].nil?
+          raise ArgumentError, "Required argument 'type' missing" if args['type'].nil?
+
+          _id = args.delete('id')
+          _memory_container_id = args.delete('memory_container_id')
+          _type = args.delete('type')
+
+          headers = args.delete('headers') || {}
+          body    = args.delete('body')
+          method  = 'DELETE'
+          url     = Utils.build_url('_plugins/_ml/memory_containers', _memory_container_id, 'memories', _type, _id)
+
+          Utils.validate_query_params! args
+          transport.perform_delete_request method, url, args, body, headers
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/ml/delete_agentic_memory_query.rb
+++ b/lib/opensearch/api/actions/ml/delete_agentic_memory_query.rb
@@ -11,17 +11,25 @@
 
 module OpenSearch
   module API
-    module SearchRelevance
+    module Ml
       module Actions
-        # Creates a new query set by sampling queries from the user behavior data.
+        # Delete multiple memories using a query to match specific criteria.
         #
-        # @option args [Hash] :body The schema for creating a query set.
-        def post_query_sets(args = {})
+        # @option args [String] :memory_container_id *Required*
+        # @option args [String] :type *Required*
+        # @option args [Hash] :body
+        def delete_agentic_memory_query(args = {})
           args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'memory_container_id' missing" if args['memory_container_id'].nil?
+          raise ArgumentError, "Required argument 'type' missing" if args['type'].nil?
+
+          _memory_container_id = args.delete('memory_container_id')
+          _type = args.delete('type')
+
           headers = args.delete('headers') || {}
           body    = args.delete('body')
           method  = 'POST'
-          url     = '_plugins/_search_relevance/query_sets'
+          url     = Utils.build_url('_plugins/_ml/memory_containers', _memory_container_id, 'memories', _type, '_delete_by_query')
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/ml/delete_memory_container.rb
+++ b/lib/opensearch/api/actions/ml/delete_memory_container.rb
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This file is generated from the OpenSearch REST API spec.
+# Do not modify it by hand. Instead, modify the generator or the spec.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Ml
+      module Actions
+        # Delete a memory container.
+        #
+        # @option args [String] :memory_container_id *Required*
+        # @option args [Boolean] :delete_all_memories
+        # @option args [Enumerable<String>] :delete_memories
+        def delete_memory_container(args = {})
+          args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'memory_container_id' missing" if args['memory_container_id'].nil?
+
+          _memory_container_id = args.delete('memory_container_id')
+
+          headers = args.delete('headers') || {}
+          body    = args.delete('body')
+          method  = 'DELETE'
+          url     = Utils.build_url('_plugins/_ml/memory_containers', _memory_container_id)
+
+          Utils.validate_query_params! args, DELETE_MEMORY_CONTAINER_QUERY_PARAMS
+          transport.perform_delete_request method, url, args, body, headers
+        end
+
+        DELETE_MEMORY_CONTAINER_QUERY_PARAMS = Set.new(%w[
+          delete_all_memories
+          delete_memories
+        ]).freeze
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/ml/execute_agent_stream.rb
+++ b/lib/opensearch/api/actions/ml/execute_agent_stream.rb
@@ -11,17 +11,22 @@
 
 module OpenSearch
   module API
-    module SearchRelevance
+    module Ml
       module Actions
-        # Creates a new query set by uploading manually.
+        # Execute an agent in streaming mode.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [String] :agent_id *Required*
+        # @option args [Hash] :body
+        def execute_agent_stream(args = {})
           args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'agent_id' missing" if args['agent_id'].nil?
+
+          _agent_id = args.delete('agent_id')
+
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = 'POST'
+          url     = Utils.build_url('_plugins/_ml/agents', _agent_id, '_execute/stream')
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/ml/execute_tool.rb
+++ b/lib/opensearch/api/actions/ml/execute_tool.rb
@@ -11,17 +11,22 @@
 
 module OpenSearch
   module API
-    module SearchRelevance
+    module Ml
       module Actions
-        # Creates a new query set by uploading manually.
+        # Execute a tool.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [String] :tool_name *Required*
+        # @option args [Hash] :body
+        def execute_tool(args = {})
           args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'tool_name' missing" if args['tool_name'].nil?
+
+          _tool_name = args.delete('tool_name')
+
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = 'POST'
+          url     = Utils.build_url('_plugins/_ml/tools/_execute', _tool_name)
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/ml/get_agentic_memory.rb
+++ b/lib/opensearch/api/actions/ml/get_agentic_memory.rb
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This file is generated from the OpenSearch REST API spec.
+# Do not modify it by hand. Instead, modify the generator or the spec.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Ml
+      module Actions
+        # Get a specific memory by its type and ID.
+        #
+        # @option args [String] :id *Required*
+        # @option args [String] :memory_container_id *Required*
+        # @option args [String] :type *Required*
+        def get_agentic_memory(args = {})
+          args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'id' missing" if args['id'].nil?
+          raise ArgumentError, "Required argument 'memory_container_id' missing" if args['memory_container_id'].nil?
+          raise ArgumentError, "Required argument 'type' missing" if args['type'].nil?
+
+          _id = args.delete('id')
+          _memory_container_id = args.delete('memory_container_id')
+          _type = args.delete('type')
+
+          headers = args.delete('headers') || {}
+          body    = args.delete('body')
+          method  = 'GET'
+          url     = Utils.build_url('_plugins/_ml/memory_containers', _memory_container_id, 'memories', _type, _id)
+
+          Utils.validate_query_params! args
+          transport.perform_request(method, url, args, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/ml/get_memory_container.rb
+++ b/lib/opensearch/api/actions/ml/get_memory_container.rb
@@ -11,17 +11,21 @@
 
 module OpenSearch
   module API
-    module SearchRelevance
+    module Ml
       module Actions
-        # Creates a new query set by uploading manually.
+        # Get a memory container.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [String] :memory_container_id *Required*
+        def get_memory_container(args = {})
           args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'memory_container_id' missing" if args['memory_container_id'].nil?
+
+          _memory_container_id = args.delete('memory_container_id')
+
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = 'GET'
+          url     = Utils.build_url('_plugins/_ml/memory_containers', _memory_container_id)
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/ml/predict_model_stream.rb
+++ b/lib/opensearch/api/actions/ml/predict_model_stream.rb
@@ -11,17 +11,22 @@
 
 module OpenSearch
   module API
-    module SearchRelevance
+    module Ml
       module Actions
-        # Creates a new query set by uploading manually.
+        # Predicts a model in streaming mode.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [String] :model_id *Required*
+        # @option args [Hash] :body
+        def predict_model_stream(args = {})
           args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'model_id' missing" if args['model_id'].nil?
+
+          _model_id = args.delete('model_id')
+
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = 'POST'
+          url     = Utils.build_url('_plugins/_ml/models', _model_id, '_predict/stream')
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/ml/search_agentic_memory.rb
+++ b/lib/opensearch/api/actions/ml/search_agentic_memory.rb
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This file is generated from the OpenSearch REST API spec.
+# Do not modify it by hand. Instead, modify the generator or the spec.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Ml
+      module Actions
+        # Search for memories of a specific type within a memory container.
+        #
+        # @option args [String] :memory_container_id *Required*
+        # @option args [String] :type *Required*
+        # @option args [Hash] :body
+        def search_agentic_memory(args = {})
+          args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'memory_container_id' missing" if args['memory_container_id'].nil?
+          raise ArgumentError, "Required argument 'type' missing" if args['type'].nil?
+
+          _memory_container_id = args.delete('memory_container_id')
+          _type = args.delete('type')
+
+          headers = args.delete('headers') || {}
+          body    = args.delete('body')
+          method  = 'GET'
+          url     = Utils.build_url('_plugins/_ml/memory_containers', _memory_container_id, 'memories', _type, '_search')
+
+          Utils.validate_query_params! args
+          transport.perform_request(method, url, args, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/ml/search_memory_container.rb
+++ b/lib/opensearch/api/actions/ml/search_memory_container.rb
@@ -11,17 +11,17 @@
 
 module OpenSearch
   module API
-    module SearchRelevance
+    module Ml
       module Actions
-        # Creates a new query set by uploading manually.
+        # Search memory containers.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [Hash] :body
+        def search_memory_container(args = {})
           args = Utils.clone_and_normalize_arguments(args)
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = body ? 'POST' : 'GET'
+          url     = '_plugins/_ml/memory_containers/_search'
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/ml/update_agentic_memory.rb
+++ b/lib/opensearch/api/actions/ml/update_agentic_memory.rb
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This file is generated from the OpenSearch REST API spec.
+# Do not modify it by hand. Instead, modify the generator or the spec.
+
+# frozen_string_literal: true
+
+module OpenSearch
+  module API
+    module Ml
+      module Actions
+        # Update a specific memory by its type and ID.
+        #
+        # @option args [String] :id *Required*
+        # @option args [String] :memory_container_id *Required*
+        # @option args [String] :type *Required*
+        # @option args [Hash] :body
+        def update_agentic_memory(args = {})
+          args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'id' missing" if args['id'].nil?
+          raise ArgumentError, "Required argument 'memory_container_id' missing" if args['memory_container_id'].nil?
+          raise ArgumentError, "Required argument 'type' missing" if args['type'].nil?
+
+          _id = args.delete('id')
+          _memory_container_id = args.delete('memory_container_id')
+          _type = args.delete('type')
+
+          headers = args.delete('headers') || {}
+          body    = args.delete('body')
+          method  = 'PUT'
+          url     = Utils.build_url('_plugins/_ml/memory_containers', _memory_container_id, 'memories', _type, _id)
+
+          Utils.validate_query_params! args
+          transport.perform_request(method, url, args, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/lib/opensearch/api/actions/ml/update_memory_container.rb
+++ b/lib/opensearch/api/actions/ml/update_memory_container.rb
@@ -11,17 +11,22 @@
 
 module OpenSearch
   module API
-    module SearchRelevance
+    module Ml
       module Actions
-        # Creates a new query set by uploading manually.
+        # Update a memory container.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [String] :memory_container_id *Required*
+        # @option args [Hash] :body
+        def update_memory_container(args = {})
           args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'memory_container_id' missing" if args['memory_container_id'].nil?
+
+          _memory_container_id = args.delete('memory_container_id')
+
           headers = args.delete('headers') || {}
           body    = args.delete('body')
           method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          url     = Utils.build_url('_plugins/_ml/memory_containers', _memory_container_id)
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/msearch.rb
+++ b/lib/opensearch/api/actions/msearch.rb
@@ -15,6 +15,7 @@ module OpenSearch
       module Actions
         # Allows to execute several search operations in one request.
         #
+        # @option args [Boolean] :allow_partial_results (default: true) Specifies whether to return partial results if there are shard request timeouts or shard failures
         # @option args [Boolean] :ccs_minimize_roundtrips (default: true) If `true`, network round-trips between the coordinating node and remote clusters are minimized for cross-cluster search requests.
         # @option args [Integer] :max_concurrent_searches Maximum number of concurrent searches the multi search API can execute.
         # @option args [Integer] :max_concurrent_shard_requests (default: 5) Maximum number of concurrent shard requests that each sub-search request executes per node.
@@ -40,6 +41,7 @@ module OpenSearch
         end
 
         MSEARCH_QUERY_PARAMS = Set.new(%w[
+          allow_partial_results
           ccs_minimize_roundtrips
           max_concurrent_searches
           max_concurrent_shard_requests

--- a/lib/opensearch/api/actions/search_relevance/delete_scheduled_experiments.rb
+++ b/lib/opensearch/api/actions/search_relevance/delete_scheduled_experiments.rb
@@ -13,18 +13,22 @@ module OpenSearch
   module API
     module SearchRelevance
       module Actions
-        # Creates a new query set by uploading manually.
+        # Deletes a specified scheduled experiment.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [String] :experiment_id *Required* The experiment id
+        def delete_scheduled_experiments(args = {})
           args = Utils.clone_and_normalize_arguments(args)
+          raise ArgumentError, "Required argument 'experiment_id' missing" if args['experiment_id'].nil?
+
+          _experiment_id = args.delete('experiment_id')
+
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = 'DELETE'
+          url     = Utils.build_url('_plugins/_search_relevance/experiments/schedule', _experiment_id)
 
           Utils.validate_query_params! args
-          transport.perform_request(method, url, args, body, headers).body
+          transport.perform_delete_request method, url, args, body, headers
         end
       end
     end

--- a/lib/opensearch/api/actions/search_relevance/get_scheduled_experiments.rb
+++ b/lib/opensearch/api/actions/search_relevance/get_scheduled_experiments.rb
@@ -13,15 +13,17 @@ module OpenSearch
   module API
     module SearchRelevance
       module Actions
-        # Creates a new query set by uploading manually.
+        # Gets the scheduled experiments.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [String] :experiment_id The experiment id
+        def get_scheduled_experiments(args = {})
           args = Utils.clone_and_normalize_arguments(args)
+          _experiment_id = args.delete('experiment_id')
+
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = 'GET'
+          url     = Utils.build_url('_plugins/_search_relevance/experiments/schedule', _experiment_id)
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/api/actions/search_relevance/post_scheduled_experiments.rb
+++ b/lib/opensearch/api/actions/search_relevance/post_scheduled_experiments.rb
@@ -13,15 +13,15 @@ module OpenSearch
   module API
     module SearchRelevance
       module Actions
-        # Creates a new query set by uploading manually.
+        # Creates a scheduled experiment.
         #
-        # @option args [Hash] :body The schema for updating a query set.
-        def put_query_sets(args = {})
+        # @option args [Hash] :body The schema for scheduling experiments.
+        def post_scheduled_experiments(args = {})
           args = Utils.clone_and_normalize_arguments(args)
           headers = args.delete('headers') || {}
           body    = args.delete('body')
-          method  = 'PUT'
-          url     = '_plugins/_search_relevance/query_sets'
+          method  = 'POST'
+          url     = '_plugins/_search_relevance/experiments/schedule'
 
           Utils.validate_query_params! args
           transport.perform_request(method, url, args, body, headers).body

--- a/lib/opensearch/version.rb
+++ b/lib/opensearch/version.rb
@@ -25,5 +25,5 @@
 # under the License.
 
 module OpenSearch
-  VERSION = '4.0.0-beta.5'.freeze
+  VERSION = '4.0.0'.freeze
 end


### PR DESCRIPTION
### Description

Cuts the final **4.0.0** release, superseding `4.0.0-beta.5`, and brings the client up to date with the latest OpenSearch API spec.

- Bump gem version `4.0.0-beta.5` → `4.0.0` (`lib/opensearch/version.rb`).
- Finalize the `4.0.0` CHANGELOG entry, consolidating all changes merged since `3.3.0` (folding in the prior `Unreleased` items).
- Regenerate the API from the latest [OpenSearch API spec](https://github.com/opensearch-project/opensearch-api-specification), which adds API surface merged upstream after the last spec-update PR (#320, 2025-11-23):
  - New `ml` actions: memory container, agentic memory, and streaming (`create_memory_container`, `add_agentic_memory`, `search_agentic_memory`, `execute_agent_stream`, `predict_model_stream`, `execute_tool`, and related — 18 new actions).
  - New `search_relevance` scheduled experiment actions (`get`/`post`/`delete_scheduled_experiments`).
  - `msearch` gains an `allow_partial_results` parameter; two `search_relevance` query-set actions get doc improvements.

### Issues Resolved

N/A — release preparation.

### Testing

- `bundle exec rubocop lib/opensearch/api` → 483 files, no offenses (includes all newly generated actions).
- `bundle exec rake test:unit` → all unit suites pass (15 + 640 RSpec examples, 116 runs, 107 tests, 0 failures).

No per-action tests are added, consistent with the existing convention for generated API actions (the generator emits no test template; the generated API is covered by the generic API specs and rubocop).

### Check List
- [x] New functionality includes testing (covered by existing generic API specs / rubocop, per convention).
- [x] New functionality has been documented (CHANGELOG).
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.