### PR TITLE
fix: update API spec download URL to api-spec.opensearch.org

### DIFF
--- a/.github/workflows/generate_api.yml
+++ b/.github/workflows/generate_api.yml
@@ -71,7 +71,7 @@ jobs:
           commit-message: "Updated opensearch-ruby to reflect the latest OpenSearch API spec (${{ env.date }})"
           title: "[AUTOCUT] Update opensearch-ruby to reflect the latest OpenSearch API spec (${{ env.date }})"
           body: |
-            Update `opensearch-ruby` to reflect the latest [OpenSearch API spec](https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml).
+            Update `opensearch-ruby` to reflect the latest [OpenSearch API spec](https://api-spec.opensearch.org/opensearch-openapi.yaml).
             Date: ${{ env.date }}
           branch: update-api-from-spec
           base: main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 - Update rubygems public key setting expiry to 20260707 ([#308](https://github.com/opensearch-project/opensearch-ruby/pull/308))
+- Updated API spec download URL to `https://api-spec.opensearch.org` ([#340](https://github.com/opensearch-project/opensearch-ruby/pull/340))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/api_generator/Rakefile
+++ b/api_generator/Rakefile
@@ -10,7 +10,7 @@ require 'rake'
 require 'active_support/all'
 
 task :download_spec do
-  sh 'curl -L -X GET "https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml" -o opensearch-openapi.yaml'
+  sh 'curl -L -X GET "https://api-spec.opensearch.org/opensearch-openapi.yaml" -o opensearch-openapi.yaml'
 end
 
 


### PR DESCRIPTION
### Description

Update the OpenAPI spec download URL from the GitHub release assets URL to the new canonical location at `https://api-spec.opensearch.org/opensearch-openapi.yaml`.

The `opensearch-api-specification` repo now publishes the spec at this new URL (see opensearch-project/opensearch-api-specification#1200).

### Changes

- `api_generator/Rakefile`: Updated curl download URL
- `.github/workflows/generate_api.yml`: Updated URL in PR body template

### Related

- opensearch-project/opensearch-api-specification#1200
- opensearch-project/opensearch-php#420
- opensearch-project/opensearch-net#1030

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).